### PR TITLE
fix: 빌드 준비 단계 불필요 작업 최적화

### DIFF
--- a/action/1_ios.sh
+++ b/action/1_ios.sh
@@ -87,9 +87,19 @@ fi
 # pod install 실행
 echo "📚 Running pod install..."
 if [ "$USE_BUNDLER" = true ]; then
-    bundle exec pod install --repo-update
+    if bundle exec pod install; then
+        true
+    else
+        echo "⚠️ pod install failed, retrying with --repo-update"
+        bundle exec pod install --repo-update
+    fi
 else
-    pod install --repo-update
+    if pod install; then
+        true
+    else
+        echo "⚠️ pod install failed, retrying with --repo-update"
+        pod install --repo-update
+    fi
 fi
 
 # # Fastlane match (필요시)

--- a/src/infrastructure/repository_workspace.py
+++ b/src/infrastructure/repository_workspace.py
@@ -65,7 +65,8 @@ class RepositoryWorkspaceManager:
         self._run_fvm_use(build_id, repo_path, env, resolved_version, log)
 
         precache_ran = False
-        if version_changed:
+        should_precache_ios = platform in {"all", "ios"}
+        if version_changed and should_precache_ios:
             self._run_flutter_precache(build_id, repo_path, env, resolved_version, platform, log)
             precache_ran = True
 
@@ -82,13 +83,15 @@ class RepositoryWorkspaceManager:
         env: Dict[str, str],
         log,
     ) -> None:
-        if not (repo_path / ".git").exists():
+        fresh_clone = not (repo_path / ".git").exists()
+        if fresh_clone:
             log(f"[{build_id}] 📦 Cloning repository into isolated workspace")
             self.command_runner.run_checked(
-                ["git", "clone", repo_url, str(repo_path)],
+                ["git", "clone", "--depth", "1", "--single-branch", "--branch", branch_name, repo_url, str(repo_path)],
                 env=env,
                 cwd=str(repo_path.parent),
             )
+            return
 
         self.command_runner.run_checked(["git", "remote", "set-url", "origin", repo_url], env=env, cwd=str(repo_path))
 

--- a/src/infrastructure/setup_executor.py
+++ b/src/infrastructure/setup_executor.py
@@ -112,7 +112,7 @@ class SetupExecutor:
         log,
     ) -> None:
         pubspec = repo_path / "pubspec.yaml"
-        has_melos = (repo_path / "melos.yaml").exists() or (repo_path / "pubspec.yaml").exists()
+        has_melos = (repo_path / "melos.yaml").exists()
         if pubspec.exists():
             git_urls = self._extract_git_dependency_urls(pubspec)
             if git_urls:
@@ -146,10 +146,10 @@ class SetupExecutor:
             if line.strip():
                 log(f"[{build_id}][SETUP] {line.strip()}")
 
-        retry_commands = [
-            ["fvm", "exec", "melos", "run", "pub"],
-            ["fvm", "flutter", "pub", "get", "--verbose"],
-        ]
+        retry_commands = []
+        if has_melos:
+            retry_commands.append(["fvm", "exec", "melos", "run", "pub"])
+        retry_commands.append(["fvm", "flutter", "pub", "get", "--verbose"])
         for command in retry_commands:
             result = self.command_runner.run(command, env=env, cwd=str(repo_path), check=False)
             for line in result.stdout.splitlines():

--- a/tests/test_repository_workspace.py
+++ b/tests/test_repository_workspace.py
@@ -5,6 +5,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from src.infrastructure.command_runner import CompletedCommand
 from src.infrastructure.repository_workspace import RepositoryWorkspaceManager
 
 
@@ -37,6 +38,19 @@ class CapturingRepositoryWorkspaceManager(RepositoryWorkspaceManager):
         self.calls.append(("write_version", flutter_version))
 
 
+class FakeCommandRunner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    def run_checked(self, command, *, env, cwd):
+        self.calls.append(tuple(command))
+        return CompletedCommand(args=list(command), returncode=0, stdout="")
+
+    def run(self, command, *, env, cwd, check=True):
+        self.calls.append(tuple(command))
+        return CompletedCommand(args=list(command), returncode=0, stdout="")
+
+
 class RepositoryWorkspaceManagerTests(unittest.TestCase):
     def test_prepare_runs_precache_when_flutter_version_changes(self) -> None:
         manager = CapturingRepositoryWorkspaceManager()
@@ -64,6 +78,64 @@ class RepositoryWorkspaceManagerTests(unittest.TestCase):
         self.assertIn(("fvm_use", "3.24.0"), manager.calls)
         self.assertIn(("precache", "3.24.0:ios"), manager.calls)
         self.assertEqual("3.24.0", manager.written_version)
+
+    def test_prepare_skips_ios_precache_for_android_only_build(self) -> None:
+        manager = CapturingRepositoryWorkspaceManager()
+        manager.previous_version = "3.22.0"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_dir = Path(tmp) / "repo"
+            repo_dir.mkdir()
+            (repo_dir / ".fvmrc").write_text('{"flutter":"3.24.0"}', encoding="utf-8")
+
+            prepared = manager.prepare(
+                build_id="build-android",
+                repo_url="git@github.com:org/repo.git",
+                branch_name="develop",
+                repo_dir=str(repo_dir),
+                env={},
+                requested_flutter_version=None,
+                platform="android",
+                log=lambda _: None,
+            )
+
+        self.assertEqual("3.24.0", prepared.flutter_version)
+        self.assertFalse(prepared.precache_ran)
+        self.assertNotIn(("precache", "3.24.0:android"), manager.calls)
+
+    def test_sync_repository_uses_shallow_clone_for_fresh_workspace(self) -> None:
+        runner = FakeCommandRunner()
+        manager = RepositoryWorkspaceManager(runner)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_path = Path(tmp) / "repo"
+            repo_path.mkdir()
+
+            manager._sync_repository(
+                build_id="build-1",
+                repo_url="git@github.com:org/repo.git",
+                branch_name="main",
+                repo_path=repo_path,
+                env={},
+                log=lambda _: None,
+            )
+
+        self.assertEqual(
+            [
+                (
+                    "git",
+                    "clone",
+                    "--depth",
+                    "1",
+                    "--single-branch",
+                    "--branch",
+                    "main",
+                    "git@github.com:org/repo.git",
+                    str(repo_path),
+                )
+            ],
+            runner.calls,
+        )
 
     def test_resolve_flutter_version_prefers_tool_versions_then_env_fallback(self) -> None:
         manager = CapturingRepositoryWorkspaceManager()

--- a/tests/test_setup_executor.py
+++ b/tests/test_setup_executor.py
@@ -34,21 +34,20 @@ class FakeCommandRunner:
 
 
 class SetupExecutorTests(unittest.TestCase):
-    def test_run_setup_repairs_cache_and_retries_pub_get(self) -> None:
+    def test_run_setup_repairs_cache_and_retries_pub_get_without_melos(self) -> None:
         runner = FakeCommandRunner()
         executor = SetupExecutor(runner)
         logs: list[str] = []
 
         runner.add_response(["fvm", "dart", "pub", "global", "activate", "melos"])
         runner.add_response(["fvm", "dart", "pub", "global", "activate", "flutterfire_cli"])
-        runner.add_response(["fvm", "exec", "melos", "run", "pub"], returncode=1, stdout="melos failed")
         runner.add_response(
             ["fvm", "flutter", "pub", "get", "--verbose"],
             returncode=1,
             stdout="pub get failed",
         )
         runner.add_response(["fvm", "flutter", "pub", "cache", "repair"], stdout="repair ok")
-        runner.add_response(["fvm", "exec", "melos", "run", "pub"], stdout="melos ok")
+        runner.add_response(["fvm", "flutter", "pub", "get", "--verbose"], stdout="pub get ok")
 
         with tempfile.TemporaryDirectory() as tmp:
             repo_dir = Path(tmp) / "repo"
@@ -67,9 +66,34 @@ class SetupExecutorTests(unittest.TestCase):
         self.assertIn(("fvm", "flutter", "pub", "cache", "repair"), runner.calls)
         self.assertEqual(
             2,
-            runner.calls.count(("fvm", "exec", "melos", "run", "pub")),
+            runner.calls.count(("fvm", "flutter", "pub", "get", "--verbose")),
         )
         self.assertTrue(any("Dependency resolution recovered" in line for line in logs))
+
+    def test_run_setup_uses_melos_only_when_workspace_file_exists(self) -> None:
+        runner = FakeCommandRunner()
+        executor = SetupExecutor(runner)
+
+        runner.add_response(["fvm", "dart", "pub", "global", "activate", "melos"])
+        runner.add_response(["fvm", "dart", "pub", "global", "activate", "flutterfire_cli"])
+        runner.add_response(["fvm", "exec", "melos", "run", "pub"], stdout="melos ok")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_dir = Path(tmp) / "repo"
+            pub_cache = Path(tmp) / "pub_cache"
+            repo_dir.mkdir()
+            (repo_dir / "pubspec.yaml").write_text("name: sample\n", encoding="utf-8")
+            (repo_dir / "melos.yaml").write_text("name: workspace\n", encoding="utf-8")
+            (pub_cache / "git" / "cache").mkdir(parents=True)
+
+            executor.run_setup(
+                build_id="build-melos",
+                repo_dir=str(repo_dir),
+                env={"PUB_CACHE": str(pub_cache)},
+                log=lambda _: None,
+            )
+
+        self.assertIn(("fvm", "exec", "melos", "run", "pub"), runner.calls)
 
     def test_prepare_ios_toolchain_uses_bundler_when_gemfile_exists(self) -> None:
         runner = FakeCommandRunner()


### PR DESCRIPTION
## 변경 요약
- fresh clone 경로에서 shallow clone을 사용하고 추가 fetch/reset/clean 단계를 건너뛰도록 정리했습니다.
- `melos.yaml`이 있을 때만 melos 기반 pub 명령을 시도하도록 변경했습니다.
- iOS `pod install`은 기본 실행 후 실패할 때만 `--repo-update`로 재시도하도록 조정했습니다.
- Android 전용 빌드에서는 Flutter SDK 변경 시 iOS precache를 수행하지 않도록 제한했습니다.
- 위 동작을 검증하는 단위 테스트를 보강했습니다.

## 테스트
- `./venv/bin/python -m unittest tests.test_repository_workspace tests.test_setup_executor`
- `make doctor`

## 주의사항
- fresh clone 최적화는 빌드별 워크스페이스가 새로 생성된다는 현재 전제를 기준으로 합니다.
- iOS CocoaPods spec 업데이트가 정말 필요한 경우에는 첫 `pod install` 실패 후 재시도 경로에서 처리됩니다.
- 플랫폼 toolchain 준비 병렬화는 아직 적용하지 않았고, Ruby/CocoaPods 캐시 분리 전략이 먼저 필요합니다.