### PR TITLE
fix: fvm use 대화형 프롬프트 차단

### DIFF
--- a/src/infrastructure/repository_workspace.py
+++ b/src/infrastructure/repository_workspace.py
@@ -172,7 +172,7 @@ class RepositoryWorkspaceManager:
         log(f"[{build_id}] 📦 Running fvm use {flutter_version}")
         try:
             result = self.command_runner.run_checked(
-                ["fvm", "use", flutter_version],
+                ["fvm", "use", flutter_version, "--force", "--skip-pub-get", "--skip-setup"],
                 env=env,
                 cwd=str(repo_path),
             )

--- a/tests/test_repository_workspace.py
+++ b/tests/test_repository_workspace.py
@@ -137,6 +137,34 @@ class RepositoryWorkspaceManagerTests(unittest.TestCase):
             runner.calls,
         )
 
+    def test_run_fvm_use_uses_non_interactive_flags(self) -> None:
+        runner = FakeCommandRunner()
+        manager = RepositoryWorkspaceManager(runner)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_path = Path(tmp)
+            manager._run_fvm_use(
+                build_id="build-1",
+                repo_path=repo_path,
+                env={},
+                flutter_version="3.41.2",
+                log=lambda _: None,
+            )
+
+        self.assertEqual(
+            [
+                (
+                    "fvm",
+                    "use",
+                    "3.41.2",
+                    "--force",
+                    "--skip-pub-get",
+                    "--skip-setup",
+                )
+            ],
+            runner.calls,
+        )
+
     def test_resolve_flutter_version_prefers_tool_versions_then_env_fallback(self) -> None:
         manager = CapturingRepositoryWorkspaceManager()
 


### PR DESCRIPTION
## 변경 요약
- `fvm use`를 `--force --skip-pub-get --skip-setup` 옵션과 함께 실행하도록 변경했습니다.
- melos 설정 확인 프롬프트가 대기 상태를 만들지 않도록 비대화형 실행 경로를 고정했습니다.
- 해당 호출 인자를 검증하는 테스트를 추가했습니다.

## 테스트
- `./venv/bin/python -m unittest tests.test_repository_workspace`
- `make doctor`

## 주의사항
- 이 변경은 `fvm use` 단계가 prompt로 멈추는 경우를 막는 목적입니다.
- 실제 지연이 남아 있으면 다음 후보는 clone 또는 precache 시간입니다.