### PR TITLE
fix: 빌드 준비 단계 런타임 블로커 수정

### DIFF
--- a/src/infrastructure/command_runner.py
+++ b/src/infrastructure/command_runner.py
@@ -46,7 +46,6 @@ class CommandRunner:
             stderr=subprocess.STDOUT,
             text=True,
             bufsize=1 if line_buffered else -1,
-            universal_newlines=line_buffered,
             env=env,
             cwd=cwd,
         )

--- a/src/infrastructure/repository_workspace.py
+++ b/src/infrastructure/repository_workspace.py
@@ -62,6 +62,7 @@ class RepositoryWorkspaceManager:
         if previous_version:
             log(f"[{build_id}] 📚 Previously synced Flutter SDK version: {previous_version}")
 
+        self._ensure_melos_sdk_path(build_id, repo_path, log)
         self._run_fvm_use(build_id, repo_path, env, resolved_version, log)
 
         precache_ran = False
@@ -182,6 +183,19 @@ class RepositoryWorkspaceManager:
         for line in result.stdout.splitlines():
             if line.strip():
                 log(f"[{build_id}][FVM] {line.strip()}")
+
+    def _ensure_melos_sdk_path(self, build_id: str, repo_path: Path, log) -> None:
+        melos_path = repo_path / "melos.yaml"
+        if not melos_path.exists():
+            return
+
+        content = melos_path.read_text(encoding="utf-8")
+        if "sdkPath:" in content:
+            log(f"[{build_id}] ✅ melos.yaml already declares sdkPath")
+            return
+
+        melos_path.write_text(f"sdkPath: .fvm/flutter_sdk\n{content}", encoding="utf-8")
+        log(f"[{build_id}] 🔧 Added sdkPath to melos.yaml before running fvm use")
 
     def _run_flutter_precache(
         self,

--- a/tests/test_command_runner.py
+++ b/tests/test_command_runner.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+
+from src.infrastructure.command_runner import CommandRunner
+
+
+class CommandRunnerTests(unittest.TestCase):
+    def test_start_supports_default_buffering_without_text_conflict(self) -> None:
+        runner = CommandRunner()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            process = runner.start(
+                ["/bin/echo", "hello"],
+                env={},
+                cwd=tmp,
+            )
+            output = list(runner.iter_lines(process))
+            return_code = runner.wait(process)
+            if process.stdout is not None:
+                process.stdout.close()
+
+        self.assertEqual(0, return_code)
+        self.assertEqual(["hello"], output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repository_workspace.py
+++ b/tests/test_repository_workspace.py
@@ -165,6 +165,21 @@ class RepositoryWorkspaceManagerTests(unittest.TestCase):
             runner.calls,
         )
 
+    def test_ensure_melos_sdk_path_adds_sdk_path_when_missing(self) -> None:
+        manager = RepositoryWorkspaceManager(FakeCommandRunner())
+        logs: list[str] = []
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_path = Path(tmp)
+            melos_path = repo_path / "melos.yaml"
+            melos_path.write_text("name: workspace\npackages:\n  - packages/**\n", encoding="utf-8")
+
+            manager._ensure_melos_sdk_path("build-1", repo_path, logs.append)
+
+            self.assertTrue(melos_path.read_text(encoding="utf-8").startswith("sdkPath: .fvm/flutter_sdk\n"))
+
+        self.assertTrue(any("Added sdkPath to melos.yaml" in line for line in logs))
+
     def test_resolve_flutter_version_prefers_tool_versions_then_env_fallback(self) -> None:
         manager = CapturingRepositoryWorkspaceManager()
 


### PR DESCRIPTION
## 변경 요약
- `fvm use` 전에 `melos.yaml`에 `sdkPath: .fvm/flutter_sdk`를 보정해 FVM의 대화형 Melos 설정 프롬프트를 피하도록 했습니다.
- `CommandRunner.start()`에서 `text=True`와 `universal_newlines` 충돌로 발생하던 런타임 예외를 제거했습니다.
- 두 변경에 대한 회귀 테스트를 추가했습니다.

## 테스트
- `./venv/bin/python -m unittest tests.test_command_runner tests.test_repository_workspace`
- `make doctor`

## 주의사항
- 이 PR은 빌드가 `environment_prepared`와 플랫폼 빌드 시작 직후에 각각 멈추던 두 런타임 블로커를 함께 다룹니다.
- 추가 지연이 남아 있으면 다음 후보는 clone 또는 precache 시간입니다.