### PR TITLE
fix: iOS에서 지정한 CocoaPods 버전 우선 사용

### DIFF
--- a/action/1_ios.sh
+++ b/action/1_ios.sh
@@ -54,6 +54,7 @@ echo ""
 FASTLANE_LANE="${FASTLANE_LANE:-beta}"
 BUILD_NAME="${BUILD_NAME:-}"
 BUILD_NUMBER="${BUILD_NUMBER:-}"
+COCOAPODS_VERSION="${COCOAPODS_VERSION:-}"
 
 # # Flutter 아티팩트 준비
 # echo "📦 Ensuring flutter artifacts..."
@@ -64,6 +65,16 @@ BUILD_NUMBER="${BUILD_NUMBER:-}"
 
 if [ "$USE_BUNDLER" = true ]; then
     echo "📦 Gemfile detected, using Bundler prepared by Python setup"
+    if [ -f "Gemfile.lock" ]; then
+        LOCKED_COCOAPODS_VERSION="$(ruby -e 'lock = File.read("Gemfile.lock"); match = lock.match(/^ {4}cocoapods \(([^)]+)\)$/); puts(match ? match[1] : "")')"
+        if [ -n "$LOCKED_COCOAPODS_VERSION" ]; then
+            echo "📦 Gemfile.lock CocoaPods version: $LOCKED_COCOAPODS_VERSION"
+        else
+            echo "⚠️ Gemfile.lock exists but CocoaPods version could not be parsed"
+        fi
+    else
+        echo "⚠️ Gemfile detected without Gemfile.lock"
+    fi
 else
     echo "📦 Using gem-based tooling prepared by Python setup"
     if ! gem list -i cocoapods > /dev/null 2>&1; then
@@ -78,15 +89,27 @@ fi
 
 # CocoaPods 버전 확인
 echo "📦 CocoaPods version:"
-if [ "$USE_BUNDLER" = true ]; then
+if [ -n "$COCOAPODS_VERSION" ]; then
+    echo "📦 Executing CocoaPods via: pod _$COCOAPODS_VERSION_"
+    pod "_$COCOAPODS_VERSION_" --version
+elif [ "$USE_BUNDLER" = true ]; then
+    echo "📦 Executing CocoaPods via: bundle exec pod"
     bundle exec pod --version
 else
+    echo "📦 Executing CocoaPods via: pod"
     pod --version
 fi
 
 # pod install 실행
 echo "📚 Running pod install..."
-if [ "$USE_BUNDLER" = true ]; then
+if [ -n "$COCOAPODS_VERSION" ]; then
+    if pod "_$COCOAPODS_VERSION_" install; then
+        true
+    else
+        echo "⚠️ pod install failed, retrying with --repo-update"
+        pod "_$COCOAPODS_VERSION_" install --repo-update
+    fi
+elif [ "$USE_BUNDLER" = true ]; then
     if bundle exec pod install; then
         true
     else

--- a/src/infrastructure/setup_executor.py
+++ b/src/infrastructure/setup_executor.py
@@ -216,6 +216,7 @@ class SetupExecutor:
             return
 
         if (ios_dir / "Gemfile").exists():
+            self._ensure_gem("cocoapods", env.get("COCOAPODS_VERSION"), ios_dir, env, build_id, log)
             self._ensure_bundler(ios_dir, env, build_id, log)
             self._bundle_install(ios_dir, env, build_id, log)
             return

--- a/tests/test_setup_executor.py
+++ b/tests/test_setup_executor.py
@@ -100,6 +100,7 @@ class SetupExecutorTests(unittest.TestCase):
         executor = SetupExecutor(runner)
         logs: list[str] = []
 
+        runner.add_response(["gem", "list", "-i", "cocoapods", "-v", "1.16.2"], returncode=0)
         runner.add_response(["gem", "list", "-i", "bundler"], returncode=0)
         runner.add_response(["bundle", "config", "set", "--local", "path", "/tmp/gems"])
         runner.add_response(["bundle", "install"], stdout="bundle ok")
@@ -114,10 +115,11 @@ class SetupExecutorTests(unittest.TestCase):
                 build_id="build-ios",
                 platform="ios",
                 repo_dir=str(repo_dir),
-                env={"GEM_HOME": "/tmp/gems"},
+                env={"GEM_HOME": "/tmp/gems", "COCOAPODS_VERSION": "1.16.2"},
                 log=logs.append,
             )
 
+        self.assertIn(("gem", "list", "-i", "cocoapods", "-v", "1.16.2"), runner.calls)
         self.assertIn(("bundle", "install"), runner.calls)
         self.assertTrue(any("Installing Ruby bundle" in line for line in logs))
 


### PR DESCRIPTION
## 변경 요약
- iOS 프로젝트에 `Gemfile`이 있어도 `COCOAPODS_VERSION`이 지정되면 해당 버전의 CocoaPods gem을 먼저 준비하도록 변경했습니다.
- `pod install` 실행 시 Bundler보다 `pod _<COCOAPODS_VERSION>_` 경로를 우선 사용하도록 조정했습니다.
- Bundler 모드에서는 `Gemfile.lock`의 CocoaPods 버전과 실제 실행 경로를 로그로 남기도록 했습니다.

## 테스트
- `./venv/bin/python -m unittest tests.test_setup_executor`
- `bash -n action/1_ios.sh`
- `make doctor`

## 주의사항
- 이 변경은 Bundler 프로젝트에서도 서버가 지정한 CocoaPods 버전을 실제 `pod install` 실행에 반영하기 위한 것입니다.
- Fastlane 실행 경로는 기존처럼 Bundler 우선 정책을 유지합니다.