### PR TITLE
fix: iOS CocoaPods 버전 변수 확장 수정

### DIFF
--- a/action/1_ios.sh
+++ b/action/1_ios.sh
@@ -90,8 +90,8 @@ fi
 # CocoaPods 버전 확인
 echo "📦 CocoaPods version:"
 if [ -n "$COCOAPODS_VERSION" ]; then
-    echo "📦 Executing CocoaPods via: pod _$COCOAPODS_VERSION_"
-    pod "_$COCOAPODS_VERSION_" --version
+    echo "📦 Executing CocoaPods via: pod _${COCOAPODS_VERSION}_"
+    pod "_${COCOAPODS_VERSION}_" --version
 elif [ "$USE_BUNDLER" = true ]; then
     echo "📦 Executing CocoaPods via: bundle exec pod"
     bundle exec pod --version
@@ -103,11 +103,11 @@ fi
 # pod install 실행
 echo "📚 Running pod install..."
 if [ -n "$COCOAPODS_VERSION" ]; then
-    if pod "_$COCOAPODS_VERSION_" install; then
+    if pod "_${COCOAPODS_VERSION}_" install; then
         true
     else
         echo "⚠️ pod install failed, retrying with --repo-update"
-        pod "_$COCOAPODS_VERSION_" install --repo-update
+        pod "_${COCOAPODS_VERSION}_" install --repo-update
     fi
 elif [ "$USE_BUNDLER" = true ]; then
     if bundle exec pod install; then


### PR DESCRIPTION
## 변경 요약
- `set -u` 환경에서 `COCOAPODS_VERSION`이 잘못된 변수명으로 해석되던 문제를 수정했습니다.
- 지정한 CocoaPods 버전 실행 경로(`pod _<version>_`)가 정상 동작하도록 보정했습니다.

## 테스트
- `bash -n action/1_ios.sh`

## 주의사항
- 이 PR은 CocoaPods 지정 버전 실행 경로의 셸 변수 확장 버그만 다룹니다.