### PR TITLE
fix: bundler gem 경로를 분리

### DIFF
--- a/src/infrastructure/setup_executor.py
+++ b/src/infrastructure/setup_executor.py
@@ -256,8 +256,9 @@ class SetupExecutor:
             self.command_runner.run_checked(["gem", "install", "-N", "bundler"], env=env, cwd=str(cwd))
 
     def _bundle_install(self, cwd: Path, env: Dict[str, str], build_id: str, log) -> None:
+        bundle_path = str(Path(env["GEM_HOME"]) / "bundle")
         self.command_runner.run_checked(
-            ["bundle", "config", "set", "--local", "path", env["GEM_HOME"]],
+            ["bundle", "config", "set", "--local", "path", bundle_path],
             env=env,
             cwd=str(cwd),
         )

--- a/tests/test_setup_executor.py
+++ b/tests/test_setup_executor.py
@@ -102,7 +102,7 @@ class SetupExecutorTests(unittest.TestCase):
 
         runner.add_response(["gem", "list", "-i", "cocoapods", "-v", "1.16.2"], returncode=0)
         runner.add_response(["gem", "list", "-i", "bundler"], returncode=0)
-        runner.add_response(["bundle", "config", "set", "--local", "path", "/tmp/gems"])
+        runner.add_response(["bundle", "config", "set", "--local", "path", "/tmp/gems/bundle"])
         runner.add_response(["bundle", "install"], stdout="bundle ok")
 
         with tempfile.TemporaryDirectory() as tmp:
@@ -120,6 +120,7 @@ class SetupExecutorTests(unittest.TestCase):
             )
 
         self.assertIn(("gem", "list", "-i", "cocoapods", "-v", "1.16.2"), runner.calls)
+        self.assertIn(("bundle", "config", "set", "--local", "path", "/tmp/gems/bundle"), runner.calls)
         self.assertIn(("bundle", "install"), runner.calls)
         self.assertTrue(any("Installing Ruby bundle" in line for line in logs))
 


### PR DESCRIPTION
## 변경 요약
- `bundle install` 경로를 `GEM_HOME` 하위의 `bundle` 디렉토리로 분리했습니다.
- 수동 설치한 CocoaPods/fastlane gem이 Bundler가 설치한 오래된 gem으로 오염되지 않도록 조정했습니다.
- 해당 경로 분리를 검증하는 테스트를 갱신했습니다.

## 테스트
- `./venv/bin/python -m unittest tests.test_setup_executor`
- `make doctor`

## 주의사항
- 이 변경은 Bundler 프로젝트에서 `GEM_HOME` 공유로 인해 CocoaPods 실행 버전이 덮어쓰이던 문제를 다룹니다.
- `pod install`에서 지정한 CocoaPods 버전 경로를 우선 사용한다는 기존 수정과 함께 동작합니다.