### PR TITLE
fix: Shorebird 웹훅 빌드 메타데이터 전달 수정

### DIFF
--- a/src/services/action_service.py
+++ b/src/services/action_service.py
@@ -91,12 +91,16 @@ class ShorebirdActionService:
         if not self._is_supported_tag_event(payload, event_type):
             return {"status": "ignored"}
 
+        build_name = self._extract_webhook_value(payload, "build_name")
+        build_number = self._extract_webhook_value(payload, "build_number")
+
         build_id = build_service.start_build_pipeline(
             flavor=os.environ.get("SHOREBIRD_PATCH_FLAVOR", "prod"),
             platform=os.environ.get("SHOREBIRD_PATCH_PLATFORM", "all"),
             trigger_source="shorebird",
             trigger_event_id=delivery_id or event_type,
-            build_name=self._payload_value(payload, "ref"),
+            build_name=build_name or self._payload_value(payload, "ref"),
+            build_number=build_number,
             branch_name=os.environ.get("SHOREBIRD_PATCH_BRANCH_NAME"),
         )
         return {"status": "ok", "build_id": build_id}
@@ -106,6 +110,19 @@ class ShorebirdActionService:
             value = payload.get(key)
             if value is not None:
                 return str(value)
+        return None
+
+    def _extract_webhook_value(self, payload: Dict[str, Any], key: str) -> Optional[str]:
+        value = self._payload_value(payload, key)
+        if value is not None:
+            return value
+
+        for container_key in ("payload", "inputs", "client_payload"):
+            nested_payload = payload.get(container_key)
+            if isinstance(nested_payload, dict):
+                value = self._payload_value(nested_payload, key)
+                if value is not None:
+                    return value
         return None
 
     def _is_supported_tag_event(self, payload: Dict[str, Any], event_type: Optional[str]) -> bool:

--- a/tests/test_action_service.py
+++ b/tests/test_action_service.py
@@ -100,6 +100,42 @@ class ShorebirdActionServiceTests(unittest.TestCase):
             trigger_source="shorebird",
             trigger_event_id="shorebird-1",
             build_name="1.2.3",
+            build_number=None,
+            branch_name="main",
+        )
+
+    @patch("src.services.action_service.build_service.start_build_pipeline")
+    def test_handle_prefers_payload_build_metadata_when_present(self, start_build_pipeline) -> None:
+        start_build_pipeline.return_value = "build-456"
+        payload = {
+            "ref_type": "tag",
+            "ref": "1.2.3",
+            "payload": {
+                "build_name": "2.2.1",
+                "build_number": "689",
+            },
+        }
+        with patch.dict(
+            os.environ,
+            {
+                "SHOREBIRD_PATCH_FLAVOR": "prod",
+                "SHOREBIRD_PATCH_PLATFORM": "ios",
+                "SHOREBIRD_PATCH_BRANCH_NAME": "main",
+            },
+            clear=False,
+        ):
+            service = ShorebirdActionService()
+
+            result = service.handle(payload, "create", "shorebird-3")
+
+        self.assertEqual({"status": "ok", "build_id": "build-456"}, result)
+        start_build_pipeline.assert_called_once_with(
+            flavor="prod",
+            platform="ios",
+            trigger_source="shorebird",
+            trigger_event_id="shorebird-3",
+            build_name="2.2.1",
+            build_number="689",
             branch_name="main",
         )
 


### PR DESCRIPTION
## 변경 요약
- `/github-action/shorebird`에서 webhook payload의 `build_name`, `build_number`를 빌드 파이프라인으로 전달하도록 수정했습니다.
- `build_name`이 없을 때만 태그 `ref`를 fallback으로 사용하도록 정리했습니다.
- top-level payload 외에 `payload`, `inputs`, `client_payload` 내부 필드도 읽도록 확장했습니다.
- 관련 회귀 테스트를 추가했습니다.

## 테스트
- `/Users/seunghwanly/Documents/local-flutter-cicd-server/venv/bin/python -m unittest tests.test_action_service`
- `/Users/seunghwanly/Documents/local-flutter-cicd-server/venv/bin/python -m compileall src`
- `bash -n action/1_android.sh action/1_ios.sh local_run.sh`

## 주의사항
- 서버 프로세스 재시작 후 webhook을 다시 호출해야 반영됩니다.
- 기존 태그 기반 fallback 동작은 유지됩니다.