### PR TITLE
fix: Shorebird 웹훅 flavor 전달 지원

### DIFF
--- a/src/services/action_service.py
+++ b/src/services/action_service.py
@@ -71,6 +71,16 @@ class GitHubActionService:
 class ShorebirdActionService:
     """Translate GitHub-delivered Shorebird tag events into build triggers."""
 
+    FLAVOR_ALIASES = {
+        "dev": "dev",
+        "development": "dev",
+        "stg": "stage",
+        "stage": "stage",
+        "prd": "prod",
+        "prod": "prod",
+        "production": "prod",
+    }
+
     def __init__(self) -> None:
         self.verifier = HmacVerifier("GITHUB_WEBHOOK_SECRET")
         self.prod_tag_pattern = os.environ.get("WEBHOOK_PROD_TAG_PATTERN", r"^\d+\.\d+\.\d+$")
@@ -91,11 +101,12 @@ class ShorebirdActionService:
         if not self._is_supported_tag_event(payload, event_type):
             return {"status": "ignored"}
 
+        flavor = self._resolve_flavor(payload)
         build_name = self._extract_webhook_value(payload, "build_name")
         build_number = self._extract_webhook_value(payload, "build_number")
 
         build_id = build_service.start_build_pipeline(
-            flavor=os.environ.get("SHOREBIRD_PATCH_FLAVOR", "prod"),
+            flavor=flavor,
             platform=os.environ.get("SHOREBIRD_PATCH_PLATFORM", "all"),
             trigger_source="shorebird",
             trigger_event_id=delivery_id or event_type,
@@ -124,6 +135,17 @@ class ShorebirdActionService:
                 if value is not None:
                     return value
         return None
+
+    def _resolve_flavor(self, payload: Dict[str, Any]) -> str:
+        requested_flavor = self._extract_webhook_value(payload, "flavor")
+        if requested_flavor is None:
+            return os.environ.get("SHOREBIRD_PATCH_FLAVOR", "prod")
+
+        normalized = self.FLAVOR_ALIASES.get(requested_flavor.strip().lower())
+        if normalized is not None:
+            return normalized
+
+        return os.environ.get("SHOREBIRD_PATCH_FLAVOR", "prod")
 
     def _is_supported_tag_event(self, payload: Dict[str, Any], event_type: Optional[str]) -> bool:
         if event_type != "create":

--- a/tests/test_action_service.py
+++ b/tests/test_action_service.py
@@ -140,6 +140,42 @@ class ShorebirdActionServiceTests(unittest.TestCase):
         )
 
     @patch("src.services.action_service.build_service.start_build_pipeline")
+    def test_handle_accepts_flavor_from_payload_alias(self, start_build_pipeline) -> None:
+        start_build_pipeline.return_value = "build-789"
+        payload = {
+            "ref_type": "tag",
+            "ref": "1.2.3",
+            "payload": {
+                "flavor": "stg",
+                "build_name": "2.2.1",
+                "build_number": "689",
+            },
+        }
+        with patch.dict(
+            os.environ,
+            {
+                "SHOREBIRD_PATCH_FLAVOR": "prod",
+                "SHOREBIRD_PATCH_PLATFORM": "ios",
+                "SHOREBIRD_PATCH_BRANCH_NAME": "main",
+            },
+            clear=False,
+        ):
+            service = ShorebirdActionService()
+
+            result = service.handle(payload, "create", "shorebird-4")
+
+        self.assertEqual({"status": "ok", "build_id": "build-789"}, result)
+        start_build_pipeline.assert_called_once_with(
+            flavor="stage",
+            platform="ios",
+            trigger_source="shorebird",
+            trigger_event_id="shorebird-4",
+            build_name="2.2.1",
+            build_number="689",
+            branch_name="main",
+        )
+
+    @patch("src.services.action_service.build_service.start_build_pipeline")
     def test_handle_ignores_non_tag_event(self, start_build_pipeline) -> None:
         service = ShorebirdActionService()
 


### PR DESCRIPTION
## 변경 요약
- `/github-action/shorebird`에서 webhook payload의 `flavor` 값을 읽어 빌드 파이프라인으로 전달하도록 수정했습니다.
- `stg`, `prd` 같은 alias를 각각 `stage`, `prod`로 정규화하도록 추가했습니다.
- flavor가 없거나 인식할 수 없는 값이면 기존처럼 `.env`의 `SHOREBIRD_PATCH_FLAVOR`를 fallback으로 사용합니다.
- 관련 회귀 테스트를 추가했습니다.

## 테스트
- `/Users/seunghwanly/Documents/local-flutter-cicd-server/venv/bin/python -m unittest tests.test_action_service`
- `/Users/seunghwanly/Documents/local-flutter-cicd-server/venv/bin/python -m compileall src`
- `bash -n action/1_android.sh action/1_ios.sh local_run.sh`

## 주의사항
- 서버 재시작 후 webhook을 다시 호출해야 반영됩니다.
- 지원 alias: `dev`, `development`, `stg`, `stage`, `prd`, `prod`, `production`