### PR TITLE
fix: Shorebird 웹훅 Swagger 입력 스키마 추가

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -2,7 +2,7 @@
 
 from typing import Optional
 
-from fastapi import FastAPI, Request, Header, HTTPException, Form
+from fastapi import FastAPI, Request, Header, HTTPException, Form, Body
 from fastapi.responses import HTMLResponse
 from pathlib import Path
 import os
@@ -11,7 +11,8 @@ from pydantic import ValidationError
 
 from ..models import (
     ActionResponse, BuildRequest, BuildStatusResponse, BuildsResponse,
-    ManualBuildResponse, RootResponse, CleanupResponse, DiagnosticsResponse
+    ManualBuildResponse, RootResponse, CleanupResponse, DiagnosticsResponse,
+    ShorebirdWebhookRequest,
 )
 from ..application import ConfigDiagnostics
 from ..services.build_service import build_service
@@ -134,6 +135,10 @@ def create_app() -> FastAPI:
     @app.post("/github-action/shorebird", response_model=ActionResponse, tags=["GitHub Actions"])
     async def handle_github_shorebird_action(
         request: Request,
+        webhook_payload: ShorebirdWebhookRequest = Body(
+            ...,
+            description="GitHub가 전달하는 Shorebird webhook payload",
+        ),
         x_hub_signature_256: str = Header(None, description="GitHub webhook signature"),
         x_hub_signature: str = Header(None, description="GitHub webhook signature (sha1)"),
         x_github_event: str = Header(None, description="GitHub event type"),
@@ -155,8 +160,11 @@ def create_app() -> FastAPI:
         if not shorebird_action_service.verify_signature(body, x_hub_signature_256, x_hub_signature):
             raise HTTPException(status_code=403, detail="Invalid signature")
 
-        payload = await request.json()
-        return shorebird_action_service.handle(payload, x_github_event, x_github_delivery)
+        return shorebird_action_service.handle(
+            webhook_payload.model_dump(exclude_none=True),
+            x_github_event,
+            x_github_delivery,
+        )
 
     @app.post("/build/shorebird", response_model=ManualBuildResponse, tags=["Manual Build"])
     async def manual_shorebird_build(

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -11,6 +11,8 @@ __all__ = [
     "BuildSummary",
     "BuildsResponse",
     "ActionResponse",
+    "ShorebirdWebhookMetadata",
+    "ShorebirdWebhookRequest",
     "ManualBuildResponse",
     "RootResponse",
     "CleanupResponse",

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -145,6 +145,83 @@ class ActionResponse(BaseModel):
     build_id: Optional[str] = None
 
 
+class ShorebirdWebhookMetadata(BaseModel):
+    """Shorebird webhook metadata payload."""
+
+    flavor: Optional[str] = Field(
+        default=None,
+        description="빌드 flavor. dev, stg, stage, prd, prod 같은 값을 지원",
+        example="stg",
+    )
+    build_name: Optional[str] = Field(
+        default=None,
+        description="빌드 이름",
+        example="2.2.1",
+    )
+    build_number: Optional[str] = Field(
+        default=None,
+        description="빌드 번호",
+        example="689",
+    )
+
+    model_config = ConfigDict(extra="allow")
+
+
+class ShorebirdWebhookRequest(BaseModel):
+    """GitHub-delivered Shorebird webhook payload for docs and validation."""
+
+    ref_type: str = Field(
+        description="GitHub ref 타입. shorebird webhook은 tag 여야 함",
+        example="tag",
+    )
+    ref: str = Field(
+        description="생성된 태그 이름. build_name fallback으로 사용",
+        example="2.2.1",
+    )
+    payload: Optional[ShorebirdWebhookMetadata] = Field(
+        default=None,
+        description="권장 메타데이터 컨테이너",
+    )
+    inputs: Optional[ShorebirdWebhookMetadata] = Field(
+        default=None,
+        description="대체 메타데이터 컨테이너",
+    )
+    client_payload: Optional[ShorebirdWebhookMetadata] = Field(
+        default=None,
+        description="대체 메타데이터 컨테이너",
+    )
+    flavor: Optional[str] = Field(
+        default=None,
+        description="top-level flavor override",
+        example="prd",
+    )
+    build_name: Optional[str] = Field(
+        default=None,
+        description="top-level build name override",
+        example="2.2.1",
+    )
+    build_number: Optional[str] = Field(
+        default=None,
+        description="top-level build number override",
+        example="689",
+    )
+
+    model_config = ConfigDict(
+        extra="allow",
+        json_schema_extra={
+            "example": {
+                "ref_type": "tag",
+                "ref": "2.2.1",
+                "payload": {
+                    "flavor": "stg",
+                    "build_name": "2.2.1",
+                    "build_number": "689",
+                },
+            }
+        },
+    )
+
+
 class ManualBuildResponse(BaseModel):
     """수동 빌드 응답 모델"""
     status: str


### PR DESCRIPTION
## 변경 요약
- `/github-action/shorebird` 요청 본문 모델을 추가해 Swagger에서 입력 필드가 보이도록 수정했습니다.
- `flavor`, `build_name`, `build_number`와 `payload`/`inputs`/`client_payload` 구조 예시를 OpenAPI에 노출합니다.
- signature 검증은 기존처럼 raw body 기준으로 유지합니다.

## 테스트
- `/Users/seunghwanly/Documents/local-flutter-cicd-server/venv/bin/python -m compileall src`
- `bash -n action/1_android.sh action/1_ios.sh local_run.sh`

## 주의사항
- Swagger에서 직접 호출할 때도 `X-Hub-Signature-256` 헤더가 없으면 403이 납니다.
- 서버 재시작 후 문서가 갱신됩니다.