### PR TITLE
fix: Shorebird 수동 빌드 flavor 입력 추가

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -180,6 +180,13 @@ GitHub가 전달한 Shorebird prod 태그 생성 이벤트를 처리합니다.
 
 Shorebird patch 배포용 빌드를 수동으로 트리거합니다.
 
+**요청 파라미터:**
+- `flavor` (string, 선택사항): `dev`, `stg`, `stage`, `prd`, `prod` 지원. 비우면 `SHOREBIRD_PATCH_FLAVOR` 또는 `prod`
+- `platform` (string, 선택사항): 대상 플랫폼 ("all", "android", "ios")
+- `build_name` (string, 선택사항): Shorebird release/tag name
+- `build_number` (string, 선택사항): Shorebird patch number
+- `branch_name` (string, 선택사항): 빌드할 Git 브랜치 이름
+
 **응답 예시:**
 ```json
 {

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -31,6 +31,21 @@ def create_app() -> FastAPI:
         docs_url="/docs",
         redoc_url="/redoc"
     )
+
+    def normalize_shorebird_manual_flavor(value: str) -> str:
+        aliases = {
+            "dev": "dev",
+            "development": "dev",
+            "stg": "stage",
+            "stage": "stage",
+            "prd": "prod",
+            "prod": "prod",
+            "production": "prod",
+        }
+        normalized = aliases.get(value.strip().lower())
+        if normalized is None:
+            raise ValueError(f"Unsupported flavor: {value}")
+        return normalized
     
     @app.get("/", response_model=RootResponse, tags=["Health Check"])
     async def root():
@@ -168,6 +183,7 @@ def create_app() -> FastAPI:
 
     @app.post("/build/shorebird", response_model=ManualBuildResponse, tags=["Manual Build"])
     async def manual_shorebird_build(
+        flavor: str = Form("", description="flavor 설정. 비우면 SHOREBIRD_PATCH_FLAVOR 또는 prod 사용. dev, stg, stage, prd, prod 지원"),
         platform: str = Form("", description="platform 설정. 비우면 SHOREBIRD_PATCH_PLATFORM 또는 all 사용"),
         build_name: Optional[str] = Form("", description="shorebird release/tag name"),
         build_number: Optional[str] = Form("", description="shorebird patch number"),
@@ -182,12 +198,18 @@ def create_app() -> FastAPI:
 
         prod 기준 Shorebird patch 배포용 빌드를 수동으로 트리거합니다.
         """
+        raw_flavor = (flavor or os.environ.get("SHOREBIRD_PATCH_FLAVOR") or "prod").strip()
         resolved_platform = (platform or os.environ.get("SHOREBIRD_PATCH_PLATFORM") or "all").strip()
         resolved_branch = (branch_name or os.environ.get("SHOREBIRD_PATCH_BRANCH_NAME") or os.environ.get("PROD_BRANCH_NAME") or "main").strip()
 
         try:
+            resolved_flavor = normalize_shorebird_manual_flavor(raw_flavor)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+        try:
             request_model = BuildRequest(
-                flavor="prod",
+                flavor=resolved_flavor,
                 platform=resolved_platform,
                 build_name=build_name,
                 build_number=build_number,


### PR DESCRIPTION
## 변경 요약
- `/build/shorebird` 수동 빌드에 `flavor` Form input을 추가했습니다.
- `dev`, `stg`, `stage`, `prd`, `prod` 값을 받아 내부적으로 `dev/stage/prod`로 정규화합니다.
- 값이 비어 있으면 기존처럼 `SHOREBIRD_PATCH_FLAVOR` 또는 `prod`를 fallback으로 사용합니다.
- API 문서에도 입력 파라미터를 반영했습니다.

## 테스트
- `/Users/seunghwanly/Documents/local-flutter-cicd-server/venv/bin/python -m compileall src`
- `bash -n action/1_android.sh action/1_ios.sh local_run.sh`

## 주의사항
- 서버 재시작 후 `/docs`를 새로고침해야 input이 보입니다.
- 지원 alias 외 값은 422로 거절됩니다.