### PR TITLE
fix: 대시보드 플랫폼별 빌드 상태 표시 수정

### DIFF
--- a/src/api/dashboard.html
+++ b/src/api/dashboard.html
@@ -305,6 +305,41 @@
             margin-right: 6px;
         }
 
+        .platform-status-list {
+            display: grid;
+            gap: 10px;
+            margin: 10px 0 4px;
+        }
+
+        .platform-status-item {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            gap: 12px;
+            background: rgba(255, 255, 255, 0.05);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: 12px;
+            padding: 10px 12px;
+        }
+
+        .platform-status-copy {
+            min-width: 0;
+        }
+
+        .platform-status-name {
+            font-size: 0.82rem;
+            color: var(--text-secondary);
+            margin-bottom: 4px;
+        }
+
+        .platform-status-message {
+            font-size: 0.88rem;
+            font-weight: 500;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
         .time {
             font-size: 0.8rem;
             color: var(--text-secondary);
@@ -656,6 +691,31 @@
             .replaceAll('_', ' ')
             .replace(/\b\w/g, (char) => char.toUpperCase());
 
+        const getPlatformLabel = (platform) => {
+            if (platform === 'android') return 'Android';
+            if (platform === 'ios') return 'iOS';
+            return String(platform || '').toUpperCase();
+        };
+
+        const renderPlatformStatuses = (platformStatuses) => {
+            const entries = Object.entries(platformStatuses || {});
+            if (!entries.length) return '';
+
+            return `
+                <div class="platform-status-list">
+                    ${entries.map(([platform, item]) => `
+                        <div class="platform-status-item">
+                            <div class="platform-status-copy">
+                                <div class="platform-status-name">${getPlatformLabel(platform)}</div>
+                                <div class="platform-status-message">${escapeHtml(item.message || '대기 중')}</div>
+                            </div>
+                            <span class="status-badge ${getStatusClass(item.status)}">${getStatusLabel(item.status)}</span>
+                        </div>
+                    `).join('')}
+                </div>
+            `;
+        };
+
         let currentBuilds = {};
         let modalPollingInterval = null;
         let currentModalBuildId = null;
@@ -774,6 +834,8 @@
                                     <span class="info-value">${humanizeStage(build.stages.find(stage => stage.status === 'running')?.name || build.stages[build.stages.length - 1]?.name || '대기 중')}</span>
                                 </div>
                                 ` : ''}
+
+                                ${renderPlatformStatuses(build.platform_statuses)}
 
                                 <div class="time">
                                     요청 시각: ${formatTime(build.started_at)}

--- a/src/application/build_status_presenter.py
+++ b/src/application/build_status_presenter.py
@@ -29,6 +29,7 @@ class BuildStatusPresenter:
             "build_name": job.build_name,
             "build_number": job.build_number,
             "queue_key": job.queue_key,
+            "platform_statuses": self._platform_statuses(job),
             "processes": {
                 name: {
                     "running": self._is_running(job, name),
@@ -78,12 +79,59 @@ class BuildStatusPresenter:
             "build_name": job.build_name,
             "build_number": job.build_number,
             "queue_key": job.queue_key,
+            "platform_statuses": self._platform_statuses(job),
+            "stages": [
+                {
+                    "name": stage.name,
+                    "status": stage.status.value,
+                    "message": stage.message,
+                    "started_at": stage.started_at,
+                    "completed_at": stage.completed_at,
+                }
+                for stage in job.stages.values()
+            ],
         }
 
     def _effective_status(self, job: BuildJob) -> BuildStatus:
         if any(self._is_running(job, key) for key in ("android", "ios")):
             return BuildStatus.RUNNING
         return job.status
+
+    def _platform_statuses(self, job: BuildJob) -> Dict[str, Dict[str, Optional[str]]]:
+        return {
+            name: self._platform_status(job, name)
+            for name in ("android", "ios")
+            if job.platform in {"all", name}
+        }
+
+    def _platform_status(self, job: BuildJob, platform_name: str) -> Dict[str, Optional[str]]:
+        toolchain_stage = job.stages.get(f"{platform_name}_toolchain_ready")
+        build_stage = job.stages.get(f"{platform_name}_build")
+        progress = job.progress.get(platform_name)
+        status = BuildStatus.PENDING.value
+        message = None
+
+        if self._is_running(job, platform_name):
+            status = BuildStatus.RUNNING.value
+        elif build_stage:
+            status = build_stage.status.value
+        elif toolchain_stage:
+            status = toolchain_stage.status.value
+        elif job.status == BuildStatus.FAILED:
+            status = BuildStatus.FAILED.value
+
+        if progress and progress.current_message:
+            message = progress.current_message
+        elif build_stage and build_stage.message:
+            message = build_stage.message
+        elif toolchain_stage and toolchain_stage.message:
+            message = toolchain_stage.message
+
+        return {
+            "status": status,
+            "label": platform_name.upper(),
+            "message": message,
+        }
 
     def _is_running(self, job: BuildJob, key: str) -> bool:
         process = job.processes.get(key)

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -107,6 +107,7 @@ class BuildStatusResponse(BaseModel):
     build_name: Optional[str] = None
     build_number: Optional[str] = None
     queue_key: Optional[str] = None
+    platform_statuses: Dict = Field(default_factory=dict)
     processes: Dict
     progress: Dict
     stages: List[Dict] = Field(default_factory=list)
@@ -132,6 +133,8 @@ class BuildSummary(BaseModel):
     build_name: Optional[str] = None
     build_number: Optional[str] = None
     queue_key: Optional[str] = None
+    platform_statuses: Dict = Field(default_factory=dict)
+    stages: List[Dict] = Field(default_factory=list)
 
 
 class BuildsResponse(BaseModel):

--- a/tests/test_build_status_presenter.py
+++ b/tests/test_build_status_presenter.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import unittest
+from unittest.mock import Mock
 
 from src.application.build_status_presenter import BuildStatusPresenter
+from src.domain import BuildStatus
 from src.domain import BuildJob, BuildRequestData
 
 
@@ -25,6 +27,43 @@ class BuildStatusPresenterTests(unittest.TestCase):
         self.assertEqual("/tmp/build.log", detail["log_file_path"])
         self.assertEqual("manual", detail["trigger_source"])
         self.assertIsNone(detail["trigger_event_id"])
+
+    def test_summary_includes_platform_statuses_for_all_builds(self) -> None:
+        request = BuildRequestData(flavor="dev", platform="all")
+        job = BuildJob.create(
+            build_id="build-2",
+            request=request,
+            branch_name="develop",
+            queue_key="dev-develop",
+        )
+        job.mark_stage_completed("android_toolchain_ready", "Android ready")
+        job.mark_stage_completed("android_build", "Android ok")
+        job.mark_stage_failed("ios_build", "Exit code 1")
+        job.status = BuildStatus.FAILED
+
+        summary = BuildStatusPresenter().summary(job)
+
+        self.assertEqual("completed", summary["platform_statuses"]["android"]["status"])
+        self.assertEqual("failed", summary["platform_statuses"]["ios"]["status"])
+        self.assertTrue(any(stage["name"] == "android_build" for stage in summary["stages"]))
+
+    def test_detail_marks_platform_running_when_process_is_active(self) -> None:
+        request = BuildRequestData(flavor="dev", platform="android")
+        job = BuildJob.create(
+            build_id="build-3",
+            request=request,
+            branch_name="develop",
+            queue_key="dev-develop",
+        )
+        process = Mock()
+        process.poll.return_value = None
+        process.returncode = None
+        job.processes["android"] = process
+
+        detail = BuildStatusPresenter().detail(job, None)
+
+        self.assertEqual("running", detail["platform_statuses"]["android"]["status"])
+        self.assertTrue(detail["processes"]["android"]["running"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약
- 빌드 요약 API에 Android/iOS별 상태 정보를 추가했습니다.
- 대시보드 카드에서 플랫폼별 성공 여부와 메시지를 각각 표시하도록 수정했습니다.
- 빌드 상태 프레젠터 테스트를 보강했습니다.

## 테스트
- make doctor
- ./venv/bin/python -m unittest tests.test_build_status_presenter

## 주의 사항
- venv에 pytest가 없어 unittest로 검증했습니다.
- 서버 재시작 후 /dashboard에서 플랫폼별 상태 표시를 확인할 수 있습니다.