### PR TITLE
fix: 대시보드 빌드 상태와 취소 제어 보강

### DIFF
--- a/src/api/dashboard.html
+++ b/src/api/dashboard.html
@@ -313,6 +313,34 @@
             text-align: right;
         }
 
+        .card-actions {
+            display: flex;
+            justify-content: flex-end;
+            margin-top: 16px;
+        }
+
+        .btn-cancel {
+            border: 1px solid rgba(239, 68, 68, 0.5);
+            background: rgba(239, 68, 68, 0.15);
+            color: #fecaca;
+            border-radius: 999px;
+            padding: 8px 14px;
+            font-size: 0.82rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .btn-cancel:hover:not(:disabled) {
+            background: rgba(239, 68, 68, 0.28);
+            transform: translateY(-1px);
+        }
+
+        .btn-cancel:disabled {
+            opacity: 0.55;
+            cursor: wait;
+        }
+
         .empty-state {
             grid-column: 1 / -1;
             text-align: center;
@@ -659,6 +687,7 @@
         let currentBuilds = {};
         let modalPollingInterval = null;
         let currentModalBuildId = null;
+        let cancelInFlight = new Set();
 
         const setConnectionState = (state, label) => {
             const dot = document.getElementById('connection-dot');
@@ -688,6 +717,23 @@
             document.getElementById('metric-running').innerText = counts.running;
             document.getElementById('metric-completed').innerText = counts.completed;
             document.getElementById('metric-failed').innerText = counts.failed;
+        };
+
+        const isCancelableStatus = (status) => {
+            const normalized = (status || '').toLowerCase();
+            return normalized === 'running' || normalized === 'pending';
+        };
+
+        const getCancelButtonHtml = (buildId, status) => {
+            if (!isCancelableStatus(status)) return '';
+            const disabled = cancelInFlight.has(buildId);
+            return `
+                <div class="card-actions">
+                    <button class="btn-cancel" onclick="cancelBuild(event, '${buildId}')" ${disabled ? 'disabled' : ''}>
+                        ${disabled ? '취소 요청 중...' : '빌드 취소'}
+                    </button>
+                </div>
+            `;
         };
 
         const fetchDiagnostics = async () => {
@@ -778,6 +824,7 @@
                                 <div class="time">
                                     요청 시각: ${formatTime(build.started_at)}
                                 </div>
+                                ${getCancelButtonHtml(build.build_id, build.status)}
                             </div>
                         `;
                     });
@@ -803,6 +850,29 @@
             } catch (error) {
                 console.error(error);
                 return null;
+            }
+        };
+
+        window.cancelBuild = async (event, buildId) => {
+            event.stopPropagation();
+            if (cancelInFlight.has(buildId)) return;
+
+            cancelInFlight.add(buildId);
+            fetchBuilds();
+            try {
+                const response = await fetch(`${API_BASE}/build/${buildId}/cancel`, { method: 'POST' });
+                if (!response.ok) {
+                    const error = await response.json().catch(() => ({}));
+                    throw new Error(error.detail || '빌드 취소 요청에 실패했습니다.');
+                }
+                if (currentModalBuildId === buildId) {
+                    await updateModalData();
+                }
+            } catch (error) {
+                alert(error.message || '빌드 취소 요청에 실패했습니다.');
+            } finally {
+                cancelInFlight.delete(buildId);
+                fetchBuilds();
             }
         };
 

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 from ..models import (
     ActionResponse, BuildRequest, BuildStatusResponse, BuildsResponse,
     ManualBuildResponse, RootResponse, CleanupResponse, DiagnosticsResponse,
+    CancelBuildResponse,
     ShorebirdWebhookRequest,
 )
 from ..application import ConfigDiagnostics
@@ -110,6 +111,22 @@ def create_app() -> FastAPI:
         """
         builds = build_service.list_builds()
         return {"builds": builds}
+
+    @app.post("/build/{build_id}/cancel", response_model=CancelBuildResponse, tags=["Build Status"])
+    async def cancel_build(build_id: str):
+        build_status = build_service.cancel_build(build_id)
+        if not build_status:
+            raise HTTPException(status_code=404, detail="Build not found")
+
+        status = build_status.get("status")
+        if status in {"completed", "failed"}:
+            raise HTTPException(status_code=409, detail=f"Build already finished with status '{status}'")
+
+        return {
+            "status": "ok",
+            "build_id": build_id,
+            "message": "Build cancellation requested",
+        }
     
     @app.post("/github-action/build", response_model=ActionResponse, tags=["GitHub Actions"])
     async def handle_github_build_action(

--- a/src/application/build_environment.py
+++ b/src/application/build_environment.py
@@ -27,7 +27,7 @@ class BuildEnvironmentAssembler:
     def __init__(self, repository_workspace_manager: RepositoryWorkspaceManager) -> None:
         self.repository_workspace_manager = repository_workspace_manager
 
-    def assemble(self, job: BuildJob, versions: ResolvedVersions, log) -> BuildRuntimeContext:
+    def assemble(self, job: BuildJob, versions: ResolvedVersions, log, should_cancel=None) -> BuildRuntimeContext:
         isolated = get_isolated_env(
             job.build_id,
             flutter_version=versions.flutter_sdk_version,
@@ -58,6 +58,7 @@ class BuildEnvironmentAssembler:
             requested_flutter_version=versions.flutter_sdk_version,
             platform=job.platform,
             log=log,
+            should_cancel=should_cancel,
         )
         job.mark_stage_completed("repository_synced", f"Repository synchronized for {job.branch_name}")
         resolved_flutter_version = prepared.flutter_version

--- a/src/application/build_orchestrator.py
+++ b/src/application/build_orchestrator.py
@@ -10,8 +10,9 @@ from typing import Dict, Optional
 from uuid import uuid4
 
 from ..core.queue_manager import queue_manager
-from ..domain import BuildJob, BuildProgress, BuildRequestData, BuildStatus
+from ..domain import BuildJob, BuildProgress, BuildRequestData, BuildStatus, StageStatus
 from ..infrastructure import BuildLogger, CommandRunner, SetupExecutor
+from ..infrastructure.command_runner import CommandCancelledError
 from .build_environment import BuildEnvironmentAssembler
 from .build_repository import BuildRepository
 from .build_status_presenter import BuildStatusPresenter
@@ -95,18 +96,46 @@ class BuildOrchestrator:
             builds.append(self.status_presenter.summary(job))
         return builds
 
+    def cancel_build(self, build_id: str) -> Optional[Dict]:
+        job = self.repository.get(build_id)
+        if not job:
+            return None
+
+        if job.status in {BuildStatus.COMPLETED, BuildStatus.FAILED, BuildStatus.CANCELED}:
+            return self.get_build_status(build_id)
+
+        with job.lock:
+            job.mark_canceled("Build canceled by user request")
+
+        self._log(job, f"[{job.build_id}] 🛑 Cancellation requested")
+        self._terminate_processes(job)
+        self.repository.save(job)
+        return self.get_build_status(build_id)
+
     def _generate_build_id(self, flavor: str, platform: str) -> str:
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
         return f"{flavor}-{platform}-{timestamp}-{uuid4().hex[:8]}"
 
     def _run_pipeline(self, job: BuildJob, request: BuildRequestData) -> None:
+        if self._is_canceled(job):
+            self._log(job, f"[{job.build_id}] 🛑 Skipping pipeline because cancellation was requested before execution")
+            self.repository.save(job)
+            return
         job.status = BuildStatus.RUNNING
         try:
             self._log(job, f"[{job.build_id}] 🛠️ [{job.flavor}] Build started")
             versions = self.version_resolver.resolve(request)
             job.resolved_flutter_sdk_version = versions.flutter_sdk_version
             job.mark_stage_running("environment_prepared", "Preparing isolated build environment")
-            runtime = self.environment_assembler.assemble(job, versions, lambda message: self._log(job, message))
+            runtime = self.environment_assembler.assemble(
+                job,
+                versions,
+                lambda message: self._log(job, message),
+                should_cancel=lambda: self._is_canceled(job),
+            )
+            if self._is_canceled(job):
+                self.repository.save(job)
+                return
             job.mark_stage_completed("environment_prepared", "Isolated build environment ready")
             env = runtime.env
 
@@ -114,7 +143,8 @@ class BuildOrchestrator:
                 return
 
             if not self._run_build_scripts(job, env):
-                job.status = BuildStatus.FAILED
+                if not self._is_canceled(job):
+                    job.status = BuildStatus.FAILED
                 self.repository.save(job)
                 return
 
@@ -124,13 +154,24 @@ class BuildOrchestrator:
                 f"[{job.build_id}] 🎉 Build pipeline completed at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
             )
             self.repository.save(job)
+        except CommandCancelledError:
+            self._mark_canceled(job, "Build canceled while executing command")
+            self.repository.save(job)
         except Exception as exc:
+            if self._is_canceled(job):
+                self._mark_canceled(job, "Build canceled by user request")
+                self.repository.save(job)
+                return
             job.status = BuildStatus.FAILED
             self._log(job, f"[{job.build_id}] 💥 Build pipeline failed: {exc}")
             logger.exception("Build pipeline failed for %s", job.build_id)
             self.repository.save(job)
 
     def _run_setup_script(self, job: BuildJob, env: Dict[str, str]) -> bool:
+        if self._is_canceled(job):
+            self._mark_canceled(job, "Build canceled before setup")
+            self.repository.save(job)
+            return False
         self._log(job, f"[{job.build_id}] 📦 Running setup...")
         job.mark_stage_running("dependencies_installed", "Resolving Flutter dependencies")
         try:
@@ -139,9 +180,18 @@ class BuildOrchestrator:
                 repo_dir=env["LOCAL_DIR"],
                 env=env,
                 log=lambda message: self._log(job, message),
+                should_cancel=lambda: self._is_canceled(job),
             )
+            if self._is_canceled(job):
+                self._mark_canceled(job, "Build canceled during setup")
+                self.repository.save(job)
+                return False
             job.mark_stage_completed("dependencies_installed", "Flutter dependencies resolved")
             return True
+        except CommandCancelledError:
+            self._mark_canceled(job, "Build canceled during setup")
+            self.repository.save(job)
+            return False
         except Exception as exc:
             job.mark_stage_failed("dependencies_installed", str(exc))
             self._log(job, f"[{job.build_id}] ❌ Setup failed: {exc}")
@@ -150,6 +200,10 @@ class BuildOrchestrator:
             return False
 
     def _run_build_scripts(self, job: BuildJob, env: Dict[str, str]) -> bool:
+        if self._is_canceled(job):
+            self._mark_canceled(job, "Build canceled before platform build")
+            self.repository.save(job)
+            return False
         commands = []
         if job.platform in {"all", "android"}:
             commands.append(("android", self._build_command("action/1_android.sh"), self._build_env(env, job)))
@@ -171,8 +225,15 @@ class BuildOrchestrator:
                     repo_dir=env["LOCAL_DIR"],
                     env=env,
                     log=lambda message: self._log(job, message),
+                    should_cancel=lambda: self._is_canceled(job),
                 )
+                if self._is_canceled(job):
+                    self._mark_canceled(job, f"{platform_name.title()} build canceled during toolchain setup")
+                    return False
                 job.mark_stage_completed(toolchain_stage, f"{platform_name.title()} toolchain ready")
+            except CommandCancelledError:
+                self._mark_canceled(job, f"{platform_name.title()} build canceled during toolchain setup")
+                return False
             except Exception as exc:
                 job.mark_stage_failed(toolchain_stage, str(exc))
                 self._log(job, f"[{job.build_id}] ❌ {platform_name.title()} toolchain setup failed: {exc}")
@@ -191,6 +252,10 @@ class BuildOrchestrator:
         success = True
         for platform_name, process in processes:
             self.command_runner.wait(process)
+            if self._is_canceled(job):
+                self._mark_canceled(job, f"{platform_name.title()} build canceled")
+                self.repository.save(job)
+                return False
             if process.returncode != 0:
                 job.mark_stage_failed(f"{platform_name}_build", f"Exit code {process.returncode}")
                 self._log(
@@ -259,3 +324,22 @@ class BuildOrchestrator:
         logger_instance = self.build_loggers.get(job.build_id)
         if logger_instance:
             logger_instance.log(message)
+        self.repository.save(job)
+
+    def _is_canceled(self, job: BuildJob) -> bool:
+        return job.status == BuildStatus.CANCELED
+
+    def _mark_canceled(self, job: BuildJob, reason: str) -> None:
+        with job.lock:
+            job.mark_canceled(reason)
+        self._log(job, f"[{job.build_id}] 🛑 {reason}")
+
+    def _terminate_processes(self, job: BuildJob) -> None:
+        for platform_name, process in list(job.processes.items()):
+            if process.poll() is not None:
+                continue
+            self._log(job, f"[{job.build_id}] 🧹 Terminating {platform_name} build process")
+            self.command_runner.terminate(process)
+            stage_name = f"{platform_name}_build"
+            if stage_name in job.stages and job.stages[stage_name].status in {StageStatus.PENDING, StageStatus.RUNNING}:
+                job.mark_stage_canceled(stage_name, "Build canceled by user request")

--- a/src/application/build_repository.py
+++ b/src/application/build_repository.py
@@ -64,7 +64,10 @@ class BuildRepository:
         """3초 주기로 변경될 가능성이 있는 빌드들의 상태를 디스크에 저장합니다."""
         while True:
             time.sleep(3.0)
-            active_jobs = [j for j in self._jobs.values() if j.status in (BuildStatus.RUNNING, BuildStatus.PENDING)]
+            active_jobs = [
+                j for j in self._jobs.values()
+                if j.status in (BuildStatus.RUNNING, BuildStatus.PENDING, BuildStatus.CANCELED)
+            ]
             for job in active_jobs:
                 self._persist_to_disk(job)
 
@@ -88,4 +91,3 @@ class BuildRepository:
 
     def list_all(self) -> List[BuildJob]:
         return list(self._jobs.values())
-

--- a/src/application/build_status_presenter.py
+++ b/src/application/build_status_presenter.py
@@ -29,6 +29,9 @@ class BuildStatusPresenter:
             "branch_name": job.branch_name,
             "build_name": job.build_name,
             "build_number": job.build_number,
+            "cancel_reason": job.cancel_reason,
+            "cancel_requested_at": job.cancel_requested_at,
+            "canceled_at": job.canceled_at,
             "queue_key": job.queue_key,
             "processes": {
                 name: {
@@ -78,16 +81,23 @@ class BuildStatusPresenter:
             "branch_name": job.branch_name,
             "build_name": job.build_name,
             "build_number": job.build_number,
+            "cancel_reason": job.cancel_reason,
+            "cancel_requested_at": job.cancel_requested_at,
+            "canceled_at": job.canceled_at,
             "queue_key": job.queue_key,
         }
 
     def _effective_status(self, job: BuildJob) -> BuildStatus:
+        if job.status == BuildStatus.CANCELED:
+            return BuildStatus.CANCELED
         if any(self._is_running(job, key) for key in ("android", "ios")):
             return BuildStatus.RUNNING
         if any(self._return_code(job, key) not in (None, 0) for key in ("android", "ios")):
             return BuildStatus.FAILED
         if any(stage.status == StageStatus.FAILED for stage in job.stages.values()):
             return BuildStatus.FAILED
+        if any(stage.status == StageStatus.CANCELED for stage in job.stages.values()):
+            return BuildStatus.CANCELED
         return job.status
 
     def _is_running(self, job: BuildJob, key: str) -> bool:

--- a/src/application/build_status_presenter.py
+++ b/src/application/build_status_presenter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Dict, Optional
 
 from ..domain import BuildJob, BuildStatus
+from ..domain.builds import StageStatus
 
 
 class BuildStatusPresenter:
@@ -83,6 +84,10 @@ class BuildStatusPresenter:
     def _effective_status(self, job: BuildJob) -> BuildStatus:
         if any(self._is_running(job, key) for key in ("android", "ios")):
             return BuildStatus.RUNNING
+        if any(self._return_code(job, key) not in (None, 0) for key in ("android", "ios")):
+            return BuildStatus.FAILED
+        if any(stage.status == StageStatus.FAILED for stage in job.stages.values()):
+            return BuildStatus.FAILED
         return job.status
 
     def _is_running(self, job: BuildJob, key: str) -> bool:

--- a/src/domain/__init__.py
+++ b/src/domain/__init__.py
@@ -1,10 +1,11 @@
 """Domain layer for build orchestration."""
 
-from .builds import BuildJob, BuildProgress, BuildRequestData, BuildStatus
+from .builds import BuildJob, BuildProgress, BuildRequestData, BuildStatus, StageStatus
 
 __all__ = [
     "BuildJob",
     "BuildProgress",
     "BuildRequestData",
     "BuildStatus",
+    "StageStatus",
 ]

--- a/src/domain/builds.py
+++ b/src/domain/builds.py
@@ -16,6 +16,7 @@ class BuildStatus(str, Enum):
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
+    CANCELED = "canceled"
 
 
 class StageStatus(str, Enum):
@@ -25,6 +26,7 @@ class StageStatus(str, Enum):
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
+    CANCELED = "canceled"
 
 
 @dataclass
@@ -84,6 +86,9 @@ class BuildJob:
     build_name: Optional[str] = None
     build_number: Optional[str] = None
     resolved_flutter_sdk_version: Optional[str] = None
+    cancel_reason: Optional[str] = None
+    cancel_requested_at: Optional[str] = None
+    canceled_at: Optional[str] = None
     status: BuildStatus = BuildStatus.PENDING
     logs: List[str] = field(default_factory=list)
     progress: Dict[str, BuildProgress] = field(default_factory=dict)
@@ -154,6 +159,24 @@ class BuildJob:
         stage.message = message
         stage.completed_at = datetime.now().isoformat()
 
+    def mark_stage_canceled(self, name: str, message: str = "") -> None:
+        stage = self.stages.setdefault(name, StageState(name=name))
+        if not stage.started_at:
+            stage.started_at = datetime.now().isoformat()
+        stage.status = StageStatus.CANCELED
+        stage.message = message
+        stage.completed_at = datetime.now().isoformat()
+
+    def mark_canceled(self, reason: str) -> None:
+        timestamp = datetime.now().isoformat()
+        self.status = BuildStatus.CANCELED
+        self.cancel_reason = reason
+        self.cancel_requested_at = self.cancel_requested_at or timestamp
+        self.canceled_at = timestamp
+        for name, stage in self.stages.items():
+            if stage.status in {StageStatus.PENDING, StageStatus.RUNNING}:
+                self.mark_stage_canceled(name, reason)
+
     def to_dict(self) -> Dict[str, Any]:
         with self.lock:
             return {
@@ -172,6 +195,9 @@ class BuildJob:
                 "build_name": self.build_name,
                 "build_number": self.build_number,
                 "resolved_flutter_sdk_version": self.resolved_flutter_sdk_version,
+                "cancel_reason": self.cancel_reason,
+                "cancel_requested_at": self.cancel_requested_at,
+                "canceled_at": self.canceled_at,
                 "status": self.status.value,
                 "logs": list(self.logs),
                 "progress": {
@@ -214,6 +240,9 @@ class BuildJob:
             build_number=data.get("build_number"),
         )
         job.resolved_flutter_sdk_version = data.get("resolved_flutter_sdk_version")
+        job.cancel_reason = data.get("cancel_reason")
+        job.cancel_requested_at = data.get("cancel_requested_at")
+        job.canceled_at = data.get("canceled_at")
         job.status = BuildStatus(data.get("status", "pending"))
         job.logs = data.get("logs", [])
 
@@ -236,4 +265,3 @@ class BuildJob:
                     completed_at=s_data.get("completed_at"),
                 )
         return job
-

--- a/src/infrastructure/command_runner.py
+++ b/src/infrastructure/command_runner.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import os
+import signal
 import subprocess
+import time
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Callable, Dict, List, Optional
 
 
 @dataclass
@@ -29,6 +32,14 @@ class CommandExecutionError(RuntimeError):
         super().__init__(summary)
 
 
+class CommandCancelledError(RuntimeError):
+    """Raised when a command is stopped because the build was canceled."""
+
+    def __init__(self, command: List[str]) -> None:
+        self.command = command
+        super().__init__(f"Command cancelled: {' '.join(command)}")
+
+
 class CommandRunner:
     """Execute commands with a consistent subprocess configuration."""
 
@@ -48,10 +59,32 @@ class CommandRunner:
             bufsize=1 if line_buffered else -1,
             env=env,
             cwd=cwd,
+            start_new_session=True,
         )
 
     def wait(self, process: subprocess.Popen) -> int:
         return process.wait()
+
+    def terminate(self, process: subprocess.Popen, *, kill_after_seconds: float = 5.0) -> None:
+        if process.poll() is not None:
+            return
+
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+
+        deadline = time.time() + kill_after_seconds
+        while process.poll() is None and time.time() < deadline:
+            time.sleep(0.1)
+
+        if process.poll() is not None:
+            return
+
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
 
     def iter_lines(self, process: subprocess.Popen):
         if process.stdout is None:
@@ -66,23 +99,34 @@ class CommandRunner:
         env: Dict[str, str],
         cwd: str,
         check: bool = True,
+        should_stop: Optional[Callable[[], bool]] = None,
     ) -> CompletedCommand:
-        completed = subprocess.run(
+        process = self.start(
             command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
             env=env,
             cwd=cwd,
-            check=False,
         )
+        stdout = ""
+        while True:
+            if should_stop and should_stop():
+                self.terminate(process)
+                try:
+                    stdout, _ = process.communicate(timeout=1)
+                except subprocess.TimeoutExpired:
+                    stdout = ""
+                raise CommandCancelledError(command)
+            try:
+                stdout, _ = process.communicate(timeout=0.5)
+                break
+            except subprocess.TimeoutExpired:
+                continue
         result = CompletedCommand(
             args=command,
-            returncode=completed.returncode,
-            stdout=completed.stdout or "",
+            returncode=process.returncode,
+            stdout=stdout or "",
         )
-        if check and completed.returncode != 0:
-            raise CommandExecutionError(command, completed.returncode, result.stdout)
+        if check and process.returncode != 0:
+            raise CommandExecutionError(command, process.returncode, result.stdout)
         return result
 
     def run_checked(
@@ -91,5 +135,6 @@ class CommandRunner:
         *,
         env: Dict[str, str],
         cwd: str,
+        should_stop: Optional[Callable[[], bool]] = None,
     ) -> CompletedCommand:
-        return self.run(command, env=env, cwd=cwd, check=True)
+        return self.run(command, env=env, cwd=cwd, check=True, should_stop=should_stop)

--- a/src/infrastructure/repository_workspace.py
+++ b/src/infrastructure/repository_workspace.py
@@ -37,6 +37,7 @@ class RepositoryWorkspaceManager:
         requested_flutter_version: Optional[str],
         platform: str,
         log,
+        should_cancel=None,
     ) -> PreparedRepositoryResult:
         repo_path = Path(repo_dir)
         repo_path.mkdir(parents=True, exist_ok=True)
@@ -48,6 +49,7 @@ class RepositoryWorkspaceManager:
             repo_path=repo_path,
             env=env,
             log=log,
+            should_cancel=should_cancel,
         )
 
         resolved_version = self._resolve_flutter_version(repo_path, requested_flutter_version)
@@ -63,12 +65,20 @@ class RepositoryWorkspaceManager:
             log(f"[{build_id}] 📚 Previously synced Flutter SDK version: {previous_version}")
 
         self._ensure_melos_sdk_path(build_id, repo_path, log)
-        self._run_fvm_use(build_id, repo_path, env, resolved_version, log)
+        self._run_fvm_use(build_id, repo_path, env, resolved_version, log, should_cancel=should_cancel)
 
         precache_ran = False
         should_precache_ios = platform in {"all", "ios"}
         if version_changed and should_precache_ios:
-            self._run_flutter_precache(build_id, repo_path, env, resolved_version, platform, log)
+            self._run_flutter_precache(
+                build_id,
+                repo_path,
+                env,
+                resolved_version,
+                platform,
+                log,
+                should_cancel=should_cancel,
+            )
             precache_ran = True
 
         self._write_previous_flutter_version(repo_url, branch_name, resolved_version)
@@ -83,6 +93,7 @@ class RepositoryWorkspaceManager:
         repo_path: Path,
         env: Dict[str, str],
         log,
+        should_cancel=None,
     ) -> None:
         fresh_clone = not (repo_path / ".git").exists()
         if fresh_clone:
@@ -91,19 +102,31 @@ class RepositoryWorkspaceManager:
                 ["git", "clone", "--depth", "1", "--single-branch", "--branch", branch_name, repo_url, str(repo_path)],
                 env=env,
                 cwd=str(repo_path.parent),
+                should_stop=should_cancel,
             )
             return
 
-        self.command_runner.run_checked(["git", "remote", "set-url", "origin", repo_url], env=env, cwd=str(repo_path))
+        self.command_runner.run_checked(
+            ["git", "remote", "set-url", "origin", repo_url],
+            env=env,
+            cwd=str(repo_path),
+            should_stop=should_cancel,
+        )
 
         log(f"[{build_id}] 🔄 Fetching latest branch state from origin/{branch_name}")
-        self.command_runner.run_checked(["git", "fetch", "origin"], env=env, cwd=str(repo_path))
+        self.command_runner.run_checked(
+            ["git", "fetch", "origin"],
+            env=env,
+            cwd=str(repo_path),
+            should_stop=should_cancel,
+        )
 
         branch_exists = self.command_runner.run(
             ["git", "ls-remote", "--heads", "origin", branch_name],
             env=env,
             cwd=str(repo_path),
             check=False,
+            should_stop=should_cancel,
         )
         if branch_exists.returncode != 0 or not branch_exists.stdout.strip():
             raise ValueError(f"Branch '{branch_name}' does not exist in remote repository")
@@ -113,22 +136,35 @@ class RepositoryWorkspaceManager:
             env=env,
             cwd=str(repo_path),
             check=False,
+            should_stop=should_cancel,
         )
         if local_branch.returncode == 0:
-            self.command_runner.run_checked(["git", "checkout", branch_name], env=env, cwd=str(repo_path))
+            self.command_runner.run_checked(
+                ["git", "checkout", branch_name],
+                env=env,
+                cwd=str(repo_path),
+                should_stop=should_cancel,
+            )
         else:
             self.command_runner.run_checked(
                 ["git", "checkout", "-B", branch_name, f"origin/{branch_name}"],
                 env=env,
                 cwd=str(repo_path),
+                should_stop=should_cancel,
             )
 
         self.command_runner.run_checked(
             ["git", "reset", "--hard", f"origin/{branch_name}"],
             env=env,
             cwd=str(repo_path),
+            should_stop=should_cancel,
         )
-        self.command_runner.run_checked(["git", "clean", "-fdx"], env=env, cwd=str(repo_path))
+        self.command_runner.run_checked(
+            ["git", "clean", "-fdx"],
+            env=env,
+            cwd=str(repo_path),
+            should_stop=should_cancel,
+        )
 
     def _resolve_flutter_version(
         self,
@@ -169,6 +205,7 @@ class RepositoryWorkspaceManager:
         env: Dict[str, str],
         flutter_version: str,
         log,
+        should_cancel=None,
     ) -> None:
         log(f"[{build_id}] 📦 Running fvm use {flutter_version}")
         try:
@@ -176,6 +213,7 @@ class RepositoryWorkspaceManager:
                 ["fvm", "use", flutter_version, "--force", "--skip-pub-get", "--skip-setup"],
                 env=env,
                 cwd=str(repo_path),
+                should_stop=should_cancel,
             )
         except CommandExecutionError as exc:
             raise RuntimeError(f"Failed to activate Flutter SDK {flutter_version}: {exc}") from exc
@@ -205,6 +243,7 @@ class RepositoryWorkspaceManager:
         flutter_version: str,
         platform: str,
         log,
+        should_cancel=None,
     ) -> None:
         log(
             f"[{build_id}] 🔄 Flutter SDK changed, running required precache for iOS "
@@ -215,6 +254,7 @@ class RepositoryWorkspaceManager:
                 ["fvm", "flutter", "precache", "--ios"],
                 env=env,
                 cwd=str(repo_path),
+                should_stop=should_cancel,
             )
         except CommandExecutionError as exc:
             raise RuntimeError(

--- a/src/infrastructure/setup_executor.py
+++ b/src/infrastructure/setup_executor.py
@@ -25,15 +25,16 @@ class SetupExecutor:
         repo_dir: str,
         env: Dict[str, str],
         log,
+        should_cancel=None,
     ) -> None:
         repo_path = Path(repo_dir)
         pub_cache = Path(env["PUB_CACHE"])
 
         log(f"[{build_id}] 📦 Running Python setup workflow")
         self._ensure_git_cache(pub_cache, build_id, log)
-        self._activate_global_package(repo_path, env, build_id, "melos", log)
-        self._activate_global_package(repo_path, env, build_id, "flutterfire_cli", log)
-        self._run_pub_get(repo_path, pub_cache, env, build_id, log)
+        self._activate_global_package(repo_path, env, build_id, "melos", log, should_cancel=should_cancel)
+        self._activate_global_package(repo_path, env, build_id, "flutterfire_cli", log, should_cancel=should_cancel)
+        self._run_pub_get(repo_path, pub_cache, env, build_id, log, should_cancel=should_cancel)
 
     def prepare_platform_toolchain(
         self,
@@ -43,12 +44,13 @@ class SetupExecutor:
         repo_dir: str,
         env: Dict[str, str],
         log,
+        should_cancel=None,
     ) -> None:
         if platform == "android":
-            self._prepare_android_toolchain(build_id, repo_dir, env, log)
+            self._prepare_android_toolchain(build_id, repo_dir, env, log, should_cancel=should_cancel)
             return
         if platform == "ios":
-            self._prepare_ios_toolchain(build_id, repo_dir, env, log)
+            self._prepare_ios_toolchain(build_id, repo_dir, env, log, should_cancel=should_cancel)
             return
         raise ValueError(f"Unsupported platform for toolchain preparation: {platform}")
 
@@ -92,12 +94,14 @@ class SetupExecutor:
         build_id: str,
         package_name: str,
         log,
+        should_cancel=None,
     ) -> None:
         log(f"[{build_id}] 🔧 Activating {package_name}")
         result = self.command_runner.run_checked(
             ["fvm", "dart", "pub", "global", "activate", package_name],
             env=env,
             cwd=str(repo_path),
+            should_stop=should_cancel,
         )
         for line in result.stdout.splitlines():
             if line.strip():
@@ -110,6 +114,7 @@ class SetupExecutor:
         env: Dict[str, str],
         build_id: str,
         log,
+        should_cancel=None,
     ) -> None:
         pubspec = repo_path / "pubspec.yaml"
         has_melos = (repo_path / "melos.yaml").exists()
@@ -126,7 +131,13 @@ class SetupExecutor:
         commands.append(["fvm", "flutter", "pub", "get", "--verbose"])
 
         for command in commands:
-            result = self.command_runner.run(command, env=env, cwd=str(repo_path), check=False)
+            result = self.command_runner.run(
+                command,
+                env=env,
+                cwd=str(repo_path),
+                check=False,
+                should_stop=should_cancel,
+            )
             for line in result.stdout.splitlines():
                 if line.strip():
                     log(f"[{build_id}][SETUP] {line.strip()}")
@@ -135,12 +146,13 @@ class SetupExecutor:
                 return
 
         log(f"[{build_id}] ⚠️ Dependency resolution failed, repairing pub cache and retrying")
-        self._log_git_dependency_access(repo_path, env, build_id, git_urls, log)
+        self._log_git_dependency_access(repo_path, env, build_id, git_urls, log, should_cancel=should_cancel)
         self._reset_git_cache(pub_cache, build_id, log)
         repair = self.command_runner.run_checked(
             ["fvm", "flutter", "pub", "cache", "repair"],
             env=env,
             cwd=str(repo_path),
+            should_stop=should_cancel,
         )
         for line in repair.stdout.splitlines():
             if line.strip():
@@ -151,7 +163,13 @@ class SetupExecutor:
             retry_commands.append(["fvm", "exec", "melos", "run", "pub"])
         retry_commands.append(["fvm", "flutter", "pub", "get", "--verbose"])
         for command in retry_commands:
-            result = self.command_runner.run(command, env=env, cwd=str(repo_path), check=False)
+            result = self.command_runner.run(
+                command,
+                env=env,
+                cwd=str(repo_path),
+                check=False,
+                should_stop=should_cancel,
+            )
             for line in result.stdout.splitlines():
                 if line.strip():
                     log(f"[{build_id}][SETUP] {line.strip()}")
@@ -176,6 +194,7 @@ class SetupExecutor:
         build_id: str,
         urls: list[str],
         log,
+        should_cancel=None,
     ) -> None:
         for url in urls:
             result = self.command_runner.run(
@@ -183,6 +202,7 @@ class SetupExecutor:
                 env=env,
                 cwd=str(repo_path),
                 check=False,
+                should_stop=should_cancel,
             )
             status = "OK" if result.returncode == 0 else "FAILED"
             log(f"[{build_id}] 🔍 Git dependency access {status}: {url}")
@@ -210,20 +230,21 @@ class SetupExecutor:
         repo_dir: str,
         env: Dict[str, str],
         log,
+        should_cancel=None,
     ) -> None:
         ios_dir = Path(repo_dir) / "ios"
         if not ios_dir.exists():
             return
 
         if (ios_dir / "Gemfile").exists():
-            self._ensure_gem("cocoapods", env.get("COCOAPODS_VERSION"), ios_dir, env, build_id, log)
-            self._ensure_bundler(ios_dir, env, build_id, log)
-            self._bundle_install(ios_dir, env, build_id, log)
+            self._ensure_gem("cocoapods", env.get("COCOAPODS_VERSION"), ios_dir, env, build_id, log, should_cancel=should_cancel)
+            self._ensure_bundler(ios_dir, env, build_id, log, should_cancel=should_cancel)
+            self._bundle_install(ios_dir, env, build_id, log, should_cancel=should_cancel)
             return
 
-        self._ensure_gem("cocoapods", env.get("COCOAPODS_VERSION"), ios_dir, env, build_id, log)
-        self._ensure_gem("fastlane", env.get("FASTLANE_VERSION"), ios_dir, env, build_id, log)
-        self._install_fastlane_plugins(ios_dir, env, build_id, log)
+        self._ensure_gem("cocoapods", env.get("COCOAPODS_VERSION"), ios_dir, env, build_id, log, should_cancel=should_cancel)
+        self._ensure_gem("fastlane", env.get("FASTLANE_VERSION"), ios_dir, env, build_id, log, should_cancel=should_cancel)
+        self._install_fastlane_plugins(ios_dir, env, build_id, log, should_cancel=should_cancel)
 
     def _prepare_android_toolchain(
         self,
@@ -231,39 +252,52 @@ class SetupExecutor:
         repo_dir: str,
         env: Dict[str, str],
         log,
+        should_cancel=None,
     ) -> None:
         android_dir = Path(repo_dir) / "android"
         if not android_dir.exists():
             return
 
         if (android_dir / "Gemfile").exists():
-            self._ensure_bundler(android_dir, env, build_id, log)
-            self._bundle_install(android_dir, env, build_id, log)
+            self._ensure_bundler(android_dir, env, build_id, log, should_cancel=should_cancel)
+            self._bundle_install(android_dir, env, build_id, log, should_cancel=should_cancel)
             return
 
-        self._ensure_digest_crc(android_dir, env, build_id, log)
-        self._ensure_gem("fastlane", env.get("FASTLANE_VERSION"), android_dir, env, build_id, log)
+        self._ensure_digest_crc(android_dir, env, build_id, log, should_cancel=should_cancel)
+        self._ensure_gem("fastlane", env.get("FASTLANE_VERSION"), android_dir, env, build_id, log, should_cancel=should_cancel)
 
-    def _ensure_bundler(self, cwd: Path, env: Dict[str, str], build_id: str, log) -> None:
+    def _ensure_bundler(self, cwd: Path, env: Dict[str, str], build_id: str, log, should_cancel=None) -> None:
         installed = self.command_runner.run(
             ["gem", "list", "-i", "bundler"],
             env=env,
             cwd=str(cwd),
             check=False,
+            should_stop=should_cancel,
         )
         if installed.returncode != 0:
             log(f"[{build_id}] 💎 Installing bundler")
-            self.command_runner.run_checked(["gem", "install", "-N", "bundler"], env=env, cwd=str(cwd))
+            self.command_runner.run_checked(
+                ["gem", "install", "-N", "bundler"],
+                env=env,
+                cwd=str(cwd),
+                should_stop=should_cancel,
+            )
 
-    def _bundle_install(self, cwd: Path, env: Dict[str, str], build_id: str, log) -> None:
+    def _bundle_install(self, cwd: Path, env: Dict[str, str], build_id: str, log, should_cancel=None) -> None:
         bundle_path = str(Path(env["GEM_HOME"]) / "bundle")
         self.command_runner.run_checked(
             ["bundle", "config", "set", "--local", "path", bundle_path],
             env=env,
             cwd=str(cwd),
+            should_stop=should_cancel,
         )
         log(f"[{build_id}] 📦 Installing Ruby bundle in {cwd.name}")
-        result = self.command_runner.run_checked(["bundle", "install"], env=env, cwd=str(cwd))
+        result = self.command_runner.run_checked(
+            ["bundle", "install"],
+            env=env,
+            cwd=str(cwd),
+            should_stop=should_cancel,
+        )
         for line in result.stdout.splitlines():
             if line.strip():
                 log(f"[{build_id}][SETUP] {line.strip()}")
@@ -276,11 +310,18 @@ class SetupExecutor:
         env: Dict[str, str],
         build_id: str,
         log,
+        should_cancel=None,
     ) -> None:
         list_command = ["gem", "list", "-i", gem_name]
         if version:
             list_command.extend(["-v", version])
-        installed = self.command_runner.run(list_command, env=env, cwd=str(cwd), check=False)
+        installed = self.command_runner.run(
+            list_command,
+            env=env,
+            cwd=str(cwd),
+            check=False,
+            should_stop=should_cancel,
+        )
         if installed.returncode == 0:
             log(f"[{build_id}] ✅ {gem_name} already available")
             return
@@ -289,9 +330,14 @@ class SetupExecutor:
         if version:
             install_command.extend(["-v", version])
         log(f"[{build_id}] 💎 Installing {gem_name}{f' {version}' if version else ''}")
-        self.command_runner.run_checked(install_command, env=env, cwd=str(cwd))
+        self.command_runner.run_checked(
+            install_command,
+            env=env,
+            cwd=str(cwd),
+            should_stop=should_cancel,
+        )
 
-    def _install_fastlane_plugins(self, ios_dir: Path, env: Dict[str, str], build_id: str, log) -> None:
+    def _install_fastlane_plugins(self, ios_dir: Path, env: Dict[str, str], build_id: str, log, should_cancel=None) -> None:
         pluginfile = ios_dir / "fastlane" / "Pluginfile"
         if not pluginfile.exists():
             return
@@ -307,6 +353,7 @@ class SetupExecutor:
                 env=env,
                 cwd=str(ios_dir),
                 check=False,
+                should_stop=should_cancel,
             )
             if installed.returncode == 0:
                 continue
@@ -315,14 +362,16 @@ class SetupExecutor:
                 ["gem", "install", "-N", plugin_name],
                 env=env,
                 cwd=str(ios_dir),
+                should_stop=should_cancel,
             )
 
-    def _ensure_digest_crc(self, cwd: Path, env: Dict[str, str], build_id: str, log) -> None:
+    def _ensure_digest_crc(self, cwd: Path, env: Dict[str, str], build_id: str, log, should_cancel=None) -> None:
         installed = self.command_runner.run(
             ["gem", "list", "-i", "digest-crc", "-v", "~> 0.4"],
             env=env,
             cwd=str(cwd),
             check=False,
+            should_stop=should_cancel,
         )
         if installed.returncode == 0:
             return
@@ -336,6 +385,7 @@ class SetupExecutor:
                     ["gem", "install", "-N", "digest-crc", "-v", version],
                     env=env,
                     cwd=str(cwd),
+                    should_stop=should_cancel,
                 )
                 return
             except CommandExecutionError as exc:

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -14,6 +14,7 @@ __all__ = [
     "ShorebirdWebhookMetadata",
     "ShorebirdWebhookRequest",
     "ManualBuildResponse",
+    "CancelBuildResponse",
     "RootResponse",
     "CleanupResponse",
     "DiagnosticItem",

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -106,6 +106,9 @@ class BuildStatusResponse(BaseModel):
     branch_name: Optional[str] = None
     build_name: Optional[str] = None
     build_number: Optional[str] = None
+    cancel_reason: Optional[str] = None
+    cancel_requested_at: Optional[str] = None
+    canceled_at: Optional[str] = None
     queue_key: Optional[str] = None
     processes: Dict
     progress: Dict
@@ -131,6 +134,9 @@ class BuildSummary(BaseModel):
     branch_name: Optional[str] = None
     build_name: Optional[str] = None
     build_number: Optional[str] = None
+    cancel_reason: Optional[str] = None
+    cancel_requested_at: Optional[str] = None
+    canceled_at: Optional[str] = None
     queue_key: Optional[str] = None
 
 
@@ -226,6 +232,13 @@ class ManualBuildResponse(BaseModel):
     """수동 빌드 응답 모델"""
     status: str
     build_id: str
+
+
+class CancelBuildResponse(BaseModel):
+    """빌드 취소 응답 모델"""
+    status: str
+    build_id: str
+    message: str
 
 
 class RootResponse(BaseModel):

--- a/src/services/build_service.py
+++ b/src/services/build_service.py
@@ -68,5 +68,8 @@ class BuildService:
     def list_builds(self):
         return self.orchestrator.list_builds()
 
+    def cancel_build(self, build_id: str):
+        return self.orchestrator.cancel_build(build_id)
+
 
 build_service = BuildService()

--- a/tests/test_build_status_presenter.py
+++ b/tests/test_build_status_presenter.py
@@ -4,6 +4,15 @@ import unittest
 
 from src.application.build_status_presenter import BuildStatusPresenter
 from src.domain import BuildJob, BuildRequestData
+from src.domain.builds import BuildStatus
+
+
+class FakeProcess:
+    def __init__(self, returncode: int | None) -> None:
+        self.returncode = returncode
+
+    def poll(self) -> int | None:
+        return self.returncode
 
 
 class BuildStatusPresenterTests(unittest.TestCase):
@@ -25,6 +34,41 @@ class BuildStatusPresenterTests(unittest.TestCase):
         self.assertEqual("/tmp/build.log", detail["log_file_path"])
         self.assertEqual("manual", detail["trigger_source"])
         self.assertIsNone(detail["trigger_event_id"])
+
+    def test_detail_marks_build_failed_when_any_stage_failed(self) -> None:
+        request = BuildRequestData(flavor="prod", platform="all")
+        job = BuildJob.create(
+            build_id="build-2",
+            request=request,
+            branch_name="main",
+            queue_key="prod-main",
+        )
+        job.status = BuildStatus.COMPLETED
+        job.mark_stage_completed("android_build", "Android completed")
+        job.mark_stage_failed("ios_build", "Exit code 1")
+
+        detail = BuildStatusPresenter().detail(job, None)
+        summary = BuildStatusPresenter().summary(job)
+
+        self.assertEqual("failed", detail["status"])
+        self.assertEqual("failed", summary["status"])
+
+    def test_detail_marks_build_failed_when_process_return_code_is_non_zero(self) -> None:
+        request = BuildRequestData(flavor="prod", platform="android")
+        job = BuildJob.create(
+            build_id="build-3",
+            request=request,
+            branch_name="main",
+            queue_key="prod-main",
+        )
+        job.status = BuildStatus.COMPLETED
+        job.processes["android"] = FakeProcess(returncode=1)
+
+        detail = BuildStatusPresenter().detail(job, None)
+        summary = BuildStatusPresenter().summary(job)
+
+        self.assertEqual("failed", detail["status"])
+        self.assertEqual("failed", summary["status"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약
- 실패 스테이지가 하나라도 있거나 프로세스 종료 코드가 0이 아니면 대시보드 상태를 failed로 계산하도록 보강
- 실행 중이거나 큐 대기 중인 빌드를 취소할 수 있도록 취소 API, 상태 모델, 프로세스 종료 흐름 추가
- 대시보드 카드에서 실행 중 빌드에 취소 버튼을 노출하고 취소 요청 상태를 표시

## 테스트
- make doctor

## 주의 사항
- 취소 요청은 즉시 canceled 상태로 표시되며, 큐 대기 중인 작업은 큐를 획득한 뒤 실제 실행 없이 종료됩니다.
- 설정/도구 준비 단계의 장기 실행 명령은 취소 신호를 주기적으로 확인한 뒤 중단합니다.