### PR TITLE
fix: 대시보드 스텝별 로그 아코디언 추가

### DIFF
--- a/src/api/dashboard.html
+++ b/src/api/dashboard.html
@@ -526,7 +526,21 @@
             background: rgba(255,255,255,0.04);
             border: 1px solid rgba(255,255,255,0.06);
             border-radius: 10px;
+            overflow: hidden;
+        }
+
+        .stage-accordion {
+            margin: 0;
+        }
+
+        .stage-summary {
+            list-style: none;
+            cursor: pointer;
             padding: 12px 14px;
+        }
+
+        .stage-summary::-webkit-details-marker {
+            display: none;
         }
 
         .stage-top {
@@ -535,6 +549,13 @@
             gap: 12px;
             align-items: center;
             margin-bottom: 6px;
+        }
+
+        .stage-top-right {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            margin-left: 12px;
         }
 
         .stage-name {
@@ -546,6 +567,51 @@
             color: var(--text-secondary);
             font-size: 0.84rem;
             line-height: 1.4;
+        }
+
+        .stage-meta {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            margin-top: 8px;
+            color: var(--text-secondary);
+            font-size: 0.76rem;
+        }
+
+        .stage-chevron {
+            color: var(--text-secondary);
+            font-size: 0.9rem;
+            transition: transform 0.2s ease;
+        }
+
+        .stage-accordion[open] .stage-chevron {
+            transform: rotate(90deg);
+        }
+
+        .stage-log-panel {
+            border-top: 1px solid rgba(255,255,255,0.06);
+            padding: 12px 14px 14px;
+            background: rgba(15, 23, 42, 0.5);
+        }
+
+        .stage-log-title {
+            font-size: 0.76rem;
+            color: var(--text-secondary);
+            margin-bottom: 10px;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+        }
+
+        .stage-log-list {
+            display: grid;
+            gap: 6px;
+            max-height: 180px;
+            overflow-y: auto;
+        }
+
+        .stage-log-empty {
+            color: var(--text-secondary);
+            font-size: 0.8rem;
         }
 
         .log-line {
@@ -727,6 +793,53 @@
         const humanizeStage = (value) => (value || '')
             .replaceAll('_', ' ')
             .replace(/\b\w/g, (char) => char.toUpperCase());
+
+        const formatStageTimeRange = (stage) => {
+            const started = stage.started_at ? formatTime(stage.started_at) : null;
+            const completed = stage.completed_at ? formatTime(stage.completed_at) : null;
+            if (started && completed) return `${started} - ${completed}`;
+            if (started) return `시작: ${started}`;
+            if (completed) return `완료: ${completed}`;
+            return '아직 실행되지 않음';
+        };
+
+        const renderStageLogs = (logs) => {
+            if (!logs || !logs.length) {
+                return '<div class="stage-log-empty">이 스텝에 기록된 로그가 아직 없습니다.</div>';
+            }
+            return `<div class="stage-log-list">${logs.map(formatLogLine).join('')}</div>`;
+        };
+
+        const renderStageItem = (stage) => {
+            const isOpen = stage.status === 'running' || stage.status === 'failed';
+            const logCount = Array.isArray(stage.logs) ? stage.logs.length : 0;
+            return `
+                <div class="stage-item">
+                    <details class="stage-accordion" ${isOpen ? 'open' : ''}>
+                        <summary class="stage-summary">
+                            <div class="stage-top">
+                                <div>
+                                    <div class="stage-name">${humanizeStage(stage.name)}</div>
+                                    <div class="stage-message">${escapeHtml(stage.message || '대기 중')}</div>
+                                    <div class="stage-meta">
+                                        <span>${formatStageTimeRange(stage)}</span>
+                                        <span>로그 ${logCount}개</span>
+                                    </div>
+                                </div>
+                                <div class="stage-top-right">
+                                    <span class="status-badge ${getStatusClass(stage.status)}">${getStatusLabel(stage.status)}</span>
+                                    <span class="stage-chevron">›</span>
+                                </div>
+                            </div>
+                        </summary>
+                        <div class="stage-log-panel">
+                            <div class="stage-log-title">Step Logs</div>
+                            ${renderStageLogs(stage.logs)}
+                        </div>
+                    </details>
+                </div>
+            `;
+        };
 
         const getPlatformLabel = (platform) => {
             if (platform === 'android') return 'Android';
@@ -965,15 +1078,7 @@
             const stageContainer = document.getElementById('modal-stages');
             const stages = data.stages || [];
             stageContainer.innerHTML = stages.length
-                ? stages.map((stage) => `
-                    <div class="stage-item">
-                        <div class="stage-top">
-                            <div class="stage-name">${humanizeStage(stage.name)}</div>
-                            <span class="status-badge ${getStatusClass(stage.status)}">${getStatusLabel(stage.status)}</span>
-                        </div>
-                        <div class="stage-message">${escapeHtml(stage.message || '대기 중')}</div>
-                    </div>
-                `).join('')
+                ? stages.map(renderStageItem).join('')
                 : '<div class="stage-item">현재 실행된 파이프라인 스테이지가 없습니다.</div>';
             
             const logContainer = document.getElementById('modal-logs');

--- a/src/application/build_orchestrator.py
+++ b/src/application/build_orchestrator.py
@@ -10,7 +10,7 @@ from typing import Dict, Optional
 from uuid import uuid4
 
 from ..core.queue_manager import queue_manager
-from ..domain import BuildJob, BuildProgress, BuildRequestData, BuildStatus, StageStatus
+from ..domain import BuildJob, BuildLogEntry, BuildProgress, BuildRequestData, BuildStatus, StageStatus
 from ..infrastructure import BuildLogger, CommandRunner, SetupExecutor
 from ..infrastructure.command_runner import CommandCancelledError
 from .build_environment import BuildEnvironmentAssembler
@@ -317,10 +317,23 @@ class BuildOrchestrator:
         return f"[{job.build_id}][{platform_name.upper()}] {line}"
 
     def _log(self, job: BuildJob, message: str) -> None:
+        timestamp = datetime.now().isoformat()
+        active_stages = [
+            name for name, stage in job.stages.items() if stage.status == StageStatus.RUNNING
+        ]
         with job.lock:
             job.logs.append(message)
+            job.log_entries.append(
+                BuildLogEntry(
+                    message=message,
+                    timestamp=timestamp,
+                    stages=active_stages,
+                )
+            )
             if len(job.logs) > MAX_LOG_LINES:
                 job.logs = job.logs[-KEEP_LOG_LINES:]
+            if len(job.log_entries) > MAX_LOG_LINES:
+                job.log_entries = job.log_entries[-KEEP_LOG_LINES:]
         logger_instance = self.build_loggers.get(job.build_id)
         if logger_instance:
             logger_instance.log(message)

--- a/src/application/build_status_presenter.py
+++ b/src/application/build_status_presenter.py
@@ -13,6 +13,7 @@ class BuildStatusPresenter:
 
     def detail(self, job: BuildJob, log_file_path: Optional[str]) -> Dict:
         status = self._effective_status(job).value
+        stage_logs = self._stage_logs(job)
         return {
             "build_id": job.build_id,
             "status": status,
@@ -58,6 +59,7 @@ class BuildStatusPresenter:
                     "message": stage.message,
                     "started_at": stage.started_at,
                     "completed_at": stage.completed_at,
+                    "logs": stage_logs.get(stage.name, []),
                 }
                 for stage in job.stages.values()
             ],
@@ -98,6 +100,14 @@ class BuildStatusPresenter:
                 for stage in job.stages.values()
             ],
         }
+
+    def _stage_logs(self, job: BuildJob) -> Dict[str, list[str]]:
+        stage_logs = {name: [] for name in job.stages.keys()}
+        for entry in job.log_entries:
+            for stage_name in entry.stages:
+                if stage_name in stage_logs:
+                    stage_logs[stage_name].append(entry.message)
+        return stage_logs
 
     def _effective_status(self, job: BuildJob) -> BuildStatus:
         if job.status == BuildStatus.CANCELED:

--- a/src/domain/__init__.py
+++ b/src/domain/__init__.py
@@ -1,9 +1,10 @@
 """Domain layer for build orchestration."""
 
-from .builds import BuildJob, BuildProgress, BuildRequestData, BuildStatus, StageStatus
+from .builds import BuildJob, BuildLogEntry, BuildProgress, BuildRequestData, BuildStatus, StageStatus
 
 __all__ = [
     "BuildJob",
+    "BuildLogEntry",
     "BuildProgress",
     "BuildRequestData",
     "BuildStatus",

--- a/src/domain/builds.py
+++ b/src/domain/builds.py
@@ -47,6 +47,15 @@ class BuildRequestData:
 
 
 @dataclass
+class BuildLogEntry:
+    """Structured log entry with optional stage attribution."""
+
+    message: str
+    timestamp: str
+    stages: List[str] = field(default_factory=list)
+
+
+@dataclass
 class BuildProgress:
     """Structured progress for a single platform build."""
 
@@ -91,6 +100,7 @@ class BuildJob:
     canceled_at: Optional[str] = None
     status: BuildStatus = BuildStatus.PENDING
     logs: List[str] = field(default_factory=list)
+    log_entries: List[BuildLogEntry] = field(default_factory=list)
     progress: Dict[str, BuildProgress] = field(default_factory=dict)
     stages: Dict[str, StageState] = field(default_factory=dict)
     processes: Dict[str, Any] = field(default_factory=dict)
@@ -200,6 +210,14 @@ class BuildJob:
                 "canceled_at": self.canceled_at,
                 "status": self.status.value,
                 "logs": list(self.logs),
+                "log_entries": [
+                    {
+                        "message": entry.message,
+                        "timestamp": entry.timestamp,
+                        "stages": list(entry.stages),
+                    }
+                    for entry in self.log_entries
+                ],
                 "progress": {
                     k: {
                         "current_step": v.current_step,
@@ -245,6 +263,14 @@ class BuildJob:
         job.canceled_at = data.get("canceled_at")
         job.status = BuildStatus(data.get("status", "pending"))
         job.logs = data.get("logs", [])
+        job.log_entries = [
+            BuildLogEntry(
+                message=entry.get("message", ""),
+                timestamp=entry.get("timestamp", ""),
+                stages=entry.get("stages", []),
+            )
+            for entry in data.get("log_entries", [])
+        ]
 
         if "progress" in data:
             for k, p_data in data["progress"].items():


### PR DESCRIPTION
## 변경 요약
- 빌드 상세보기의 스테이지 목록을 아코디언 UI로 변경했습니다.
- 각 스테이지에 해당하는 로그만 펼쳐서 볼 수 있도록 백엔드에서 stage별 로그를 집계해 내려주도록 했습니다.
- 실행 중이거나 실패한 스텝은 기본으로 펼쳐져 현재 문제 구간을 바로 확인할 수 있게 했습니다.

## 테스트
- `make doctor`

## 주의사항
- 기존 전체 로그 패널은 그대로 유지됩니다.
- stage별 로그는 변경 이후부터 수집되는 구조화 로그를 기준으로 표시됩니다.