### PR TITLE
chore: 로컬 서버 재시작 스크립트 추가

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ run:
 
 doctor:
 	./venv/bin/python -m compileall src
-	bash -n action/1_android.sh action/1_ios.sh local_run.sh
+	bash -n action/1_android.sh action/1_ios.sh local_run.sh scripts/restart_local_server.sh
 
 test:
 	./venv/bin/python -m unittest discover -s tests -p 'test_*.py'

--- a/scripts/restart_local_server.sh
+++ b/scripts/restart_local_server.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PORT="${PORT:-8000}"
+
+cd "$ROOT_DIR"
+
+ensure_clean_worktree() {
+    if [ -n "$(git status --porcelain)" ]; then
+        echo "❌ 작업 트리가 깨끗하지 않습니다. 변경사항을 정리한 뒤 다시 시도하세요."
+        git status --short
+        exit 1
+    fi
+}
+
+stop_existing_server() {
+    local pids
+    pids="$(lsof -tiTCP:"$PORT" -sTCP:LISTEN || true)"
+
+    if [ -z "$pids" ]; then
+        echo "ℹ️ 포트 $PORT 에서 실행 중인 서버가 없습니다."
+        return
+    fi
+
+    echo "🛑 포트 $PORT 에서 실행 중인 서버를 확인합니다..."
+
+    for pid in $pids; do
+        local command
+        command="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+
+        if [[ "$command" != *"$ROOT_DIR"* && "$command" != *"uvicorn src.main:app"* && "$command" != *"local_run.sh"* ]]; then
+            echo "❌ 포트 $PORT 를 사용 중인 프로세스가 이 저장소의 서버로 보이지 않습니다."
+            echo "   PID: $pid"
+            echo "   CMD: $command"
+            exit 1
+        fi
+
+        echo "   종료 중: PID $pid"
+        kill "$pid"
+    done
+
+    for pid in $pids; do
+        local wait_count=0
+        while kill -0 "$pid" 2>/dev/null; do
+            if [ "$wait_count" -ge 30 ]; then
+                echo "   강제 종료: PID $pid"
+                kill -9 "$pid" 2>/dev/null || true
+                break
+            fi
+            sleep 1
+            wait_count=$((wait_count + 1))
+        done
+    done
+
+    echo "✅ 기존 서버를 중지했습니다."
+}
+
+sync_main_branch() {
+    echo "🔄 origin/main 최신 상태를 가져옵니다..."
+    git fetch origin
+    git checkout main
+    git pull origin main
+}
+
+start_server() {
+    echo "🚀 ./local_run.sh 로 서버를 다시 시작합니다..."
+    exec ./local_run.sh
+}
+
+ensure_clean_worktree
+stop_existing_server
+sync_main_branch
+start_server


### PR DESCRIPTION
## 변경 요약
- 실행 중인 로컬 CI/CD 서버를 중지하고 다시 띄우는 `scripts/restart_local_server.sh`를 추가했습니다.
- 스크립트는 작업 트리가 깨끗한지 확인한 뒤, 포트 8000에서 이 저장소의 서버로 보이는 프로세스를 종료합니다.
- 이후 `git fetch origin`, `git checkout main`, `git pull origin main`, `./local_run.sh` 순서로 최신 main 기준 재기동합니다.
- `make doctor`가 새 스크립트의 쉘 문법도 함께 검사하도록 갱신했습니다.

## 테스트
- `python3 -m compileall src`
- `bash -n action/1_android.sh action/1_ios.sh local_run.sh scripts/restart_local_server.sh`
- 참고: 새 worktree에는 `venv`가 없어 `make doctor`는 그대로 실행되지 않았습니다.

## 주의사항
- 작업 트리가 더러우면 `git checkout main` 전에 중단합니다.
- 포트 8000을 사용하는 프로세스가 이 저장소의 서버로 보이지 않으면 안전을 위해 종료하지 않고 실패합니다.