### PR TITLE
fix: 원격 실행용 백그라운드 서버 시작 지원

### DIFF
--- a/scripts/restart_local_server.sh
+++ b/scripts/restart_local_server.sh
@@ -4,8 +4,13 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PORT="${PORT:-8000}"
+RUNTIME_DIR="$ROOT_DIR/.workspace/runtime"
+PID_FILE="$RUNTIME_DIR/server.pid"
+LOG_FILE="$RUNTIME_DIR/server.log"
 
 cd "$ROOT_DIR"
+
+mkdir -p "$RUNTIME_DIR"
 
 ensure_clean_worktree() {
     if [ -n "$(git status --porcelain)" ]; then
@@ -55,6 +60,7 @@ stop_existing_server() {
     done
 
     echo "✅ 기존 서버를 중지했습니다."
+    rm -f "$PID_FILE"
 }
 
 sync_main_branch() {
@@ -65,8 +71,20 @@ sync_main_branch() {
 }
 
 start_server() {
-    echo "🚀 ./local_run.sh 로 서버를 다시 시작합니다..."
-    exec ./local_run.sh
+    echo "🚀 원격 터미널과 분리된 백그라운드 프로세스로 서버를 시작합니다..."
+    nohup ./local_run.sh >"$LOG_FILE" 2>&1 </dev/null &
+    local server_pid=$!
+    echo "$server_pid" > "$PID_FILE"
+    sleep 2
+
+    if ! kill -0 "$server_pid" 2>/dev/null; then
+        echo "❌ 서버 시작에 실패했습니다. 로그를 확인하세요: $LOG_FILE"
+        exit 1
+    fi
+
+    echo "✅ 서버를 시작했습니다."
+    echo "   PID: $server_pid"
+    echo "   LOG: $LOG_FILE"
 }
 
 ensure_clean_worktree


### PR DESCRIPTION
## 변경 요약
- `scripts/restart_local_server.sh`가 `./local_run.sh`를 포그라운드로 붙잡지 않고 백그라운드 프로세스로 실행하도록 수정했습니다.
- 원격 데스크톱이나 SSH 터미널이 종료되어도 서버 프로세스가 계속 유지되도록 `nohup` 기반 detached 실행으로 바꿨습니다.
- 실행 PID와 로그 경로를 `.workspace/runtime/server.pid`, `.workspace/runtime/server.log`에 남기고, 기존 서버 종료 시 PID 파일도 정리합니다.

## 테스트
- `bash -n scripts/restart_local_server.sh`

## 주의사항
- 이 PR은 이미 main에 반영된 `restart_local_server.sh` 추가 위에, 누락된 백그라운드 실행 수정만 추가합니다.
- 실제 실행 로그는 `.workspace/runtime/server.log`에서 확인할 수 있습니다.