### PR TITLE
fix: 대시보드 카드 overflow 줄바꿈 처리

### DIFF
--- a/src/api/dashboard.html
+++ b/src/api/dashboard.html
@@ -279,7 +279,9 @@
         .info-row {
             display: flex;
             margin-bottom: 12px;
-            align-items: center;
+            align-items: flex-start;
+            gap: 12px;
+            min-width: 0;
         }
 
         .info-label {
@@ -292,9 +294,11 @@
         .info-value {
             font-weight: 500;
             font-size: 0.9rem;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
+            flex: 1 1 auto;
+            min-width: 0;
+            white-space: normal;
+            overflow-wrap: anywhere;
+            word-break: break-word;
         }
 
         .tag {
@@ -303,6 +307,12 @@
             border-radius: 4px;
             font-size: 0.8rem;
             margin-right: 6px;
+            margin-bottom: 6px;
+            display: inline-block;
+            max-width: 100%;
+            white-space: normal;
+            overflow-wrap: anywhere;
+            word-break: break-word;
         }
 
         .platform-status-list {
@@ -314,7 +324,7 @@
         .platform-status-item {
             display: flex;
             justify-content: space-between;
-            align-items: center;
+            align-items: flex-start;
             gap: 12px;
             background: rgba(255, 255, 255, 0.05);
             border: 1px solid rgba(255, 255, 255, 0.06);
@@ -335,9 +345,9 @@
         .platform-status-message {
             font-size: 0.88rem;
             font-weight: 500;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
+            white-space: normal;
+            overflow-wrap: anywhere;
+            word-break: break-word;
         }
 
         .time {


### PR DESCRIPTION
## 변경 요약
- 빌드 대시보드 카드의 `.info-row`, `.info-value`에 `min-width`와 줄바꿈 규칙을 추가했습니다.
- 긴 브랜치명/상태 문구가 줄바꿈 없이 카드 폭을 밀어내던 문제를 막기 위해 `.tag`, `.platform-status-message`도 wrapping 가능하게 조정했습니다.
- 플랫폼 상태 행은 긴 메시지에서도 상단 정렬이 유지되도록 정렬 기준을 함께 수정했습니다.

## 테스트 / 검증
- 자동 테스트는 실행하지 않았습니다.
- 정적 코드 검토로 카드 메타 영역의 `white-space: nowrap` / `text-overflow: ellipsis` 경로를 제거하고 wrapping 규칙이 적용되도록 확인했습니다.

## 주의사항 / 후속 작업
- UI 변경은 `src/api/dashboard.html` 한 파일만 포함합니다.
- 실제 긴 브랜치명, 긴 stage/status 메시지로 브라우저에서 한 번 확인하면 좋습니다.