### PR TITLE
fix: ruby 3.2 기준으로 bundler 호환성 정렬

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ cp env.template .env
 | 항목 | 키 | 설명 |
 |------|----|------|
 | Flutter 버전 | `FLUTTER_VERSION` | `.fvmrc`/`.tool-versions`가 없을 때만 쓰는 fallback Flutter SDK 버전 |
+| Ruby 버전 | `RUBY_VERSION` | `.ruby-version`/`.tool-versions`/`Gemfile.lock` 기준이 없을 때 쓰는 fallback Ruby 버전. 기본값은 `3.2.0` |
 | Git 리포 | `REPO_URL` | Git 리포지토리 주소 |
 | 브랜치 이름 | `DEV_BRANCH_NAME` / `PROD_BRANCH_NAME` | 배포 대상 브랜치 |
 | Fastlane Lane | `DEV_FASTLANE_LANE` / `PROD_FASTLANE_LANE` | Fastlane에서 실행할 lane 이름 |

--- a/env.template
+++ b/env.template
@@ -11,6 +11,7 @@ REPO_URL=git@github.com:your_org/your_repo.git
 GITHUB_TOKEN=ghp_your_token_here
 
 FLUTTER_VERSION=3.29.3
+RUBY_VERSION=3.2.0
 
 # 일반 빌드 lane 설정 (/build)
 DEV_BRANCH_NAME=develop

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -369,6 +369,7 @@ def get_isolated_env(build_id: str, flutter_version: str = None, gradle_version:
     env["DERIVED_DATA_PATH"] = str(deriveddata_cache_dir)
     env["PATH"] = f"{gem_home_dir / 'bin'}:{pub_cache_dir / 'bin'}:{env.get('PATH', '/usr/local/bin:/usr/bin:/bin')}"
     env["HOME"] = str(Path.home().resolve())  # 명시적 HOME 설정 (절대 경로)
+    env["RUBY_VERSION"] = env.get("RUBY_VERSION", "3.2.0")
     
     # Git 자격증명 설정
     setup_git_credentials(workspace, env)

--- a/src/infrastructure/setup_executor.py
+++ b/src/infrastructure/setup_executor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 from pathlib import Path
@@ -14,6 +15,7 @@ class SetupExecutor:
     """Prepare Flutter and Ruby toolchains before platform build scripts run."""
 
     _GIT_URL_PATTERN = re.compile(r"url:\s*([^\s]+)")
+    _VERSION_PATTERN = re.compile(r"(\d+(?:\.\d+)+)")
 
     def __init__(self, command_runner: CommandRunner) -> None:
         self.command_runner = command_runner
@@ -236,10 +238,11 @@ class SetupExecutor:
         if not ios_dir.exists():
             return
 
+        self._configure_ruby_environment(ios_dir, env, build_id, log, should_cancel=should_cancel)
         if (ios_dir / "Gemfile").exists():
             self._ensure_gem("cocoapods", env.get("COCOAPODS_VERSION"), ios_dir, env, build_id, log, should_cancel=should_cancel)
-            self._ensure_bundler(ios_dir, env, build_id, log, should_cancel=should_cancel)
-            self._bundle_install(ios_dir, env, build_id, log, should_cancel=should_cancel)
+            bundler_version = self._ensure_bundler(ios_dir, env, build_id, log, should_cancel=should_cancel)
+            self._bundle_install(ios_dir, env, build_id, log, bundler_version=bundler_version, should_cancel=should_cancel)
             return
 
         self._ensure_gem("cocoapods", env.get("COCOAPODS_VERSION"), ios_dir, env, build_id, log, should_cancel=should_cancel)
@@ -258,15 +261,71 @@ class SetupExecutor:
         if not android_dir.exists():
             return
 
+        self._configure_ruby_environment(android_dir, env, build_id, log, should_cancel=should_cancel)
         if (android_dir / "Gemfile").exists():
-            self._ensure_bundler(android_dir, env, build_id, log, should_cancel=should_cancel)
-            self._bundle_install(android_dir, env, build_id, log, should_cancel=should_cancel)
+            bundler_version = self._ensure_bundler(android_dir, env, build_id, log, should_cancel=should_cancel)
+            self._bundle_install(android_dir, env, build_id, log, bundler_version=bundler_version, should_cancel=should_cancel)
             return
 
         self._ensure_digest_crc(android_dir, env, build_id, log, should_cancel=should_cancel)
         self._ensure_gem("fastlane", env.get("FASTLANE_VERSION"), android_dir, env, build_id, log, should_cancel=should_cancel)
 
-    def _ensure_bundler(self, cwd: Path, env: Dict[str, str], build_id: str, log, should_cancel=None) -> None:
+    def _configure_ruby_environment(self, cwd: Path, env: Dict[str, str], build_id: str, log, should_cancel=None) -> None:
+        self._prepend_rbenv_to_path(env)
+
+        requested_ruby, requested_source = self._resolve_requested_ruby_version(cwd, env)
+        if requested_ruby:
+            log(f"[{build_id}] 💎 Requested Ruby version: {requested_ruby}")
+            selected_ruby = self._select_ruby_version(
+                cwd,
+                env,
+                requested_ruby,
+                requested_source or "unknown",
+                build_id,
+                log,
+                should_cancel=should_cancel,
+            )
+            if selected_ruby:
+                env["RBENV_VERSION"] = selected_ruby
+
+        current_ruby = self._current_ruby_version(cwd, env, should_cancel=should_cancel)
+        if current_ruby:
+            log(f"[{build_id}] 💎 Active Ruby version: {current_ruby}")
+
+        lockfile_ruby = self._parse_lockfile_ruby_version(cwd)
+        if lockfile_ruby and current_ruby and self._compare_versions(current_ruby, lockfile_ruby) < 0:
+            raise RuntimeError(
+                f"Gemfile.lock requires Ruby {lockfile_ruby}+ but active Ruby is {current_ruby}. "
+                "Install that version with rbenv and set RUBY_VERSION, .ruby-version, or .tool-versions."
+            )
+
+    def _ensure_bundler(
+        self,
+        cwd: Path,
+        env: Dict[str, str],
+        build_id: str,
+        log,
+        should_cancel=None,
+    ) -> str | None:
+        locked_version = self._parse_lockfile_bundler_version(cwd)
+        if locked_version:
+            installed = self.command_runner.run(
+                ["gem", "list", "-i", "bundler", "-v", locked_version],
+                env=env,
+                cwd=str(cwd),
+                check=False,
+                should_stop=should_cancel,
+            )
+            if installed.returncode != 0:
+                log(f"[{build_id}] 💎 Installing bundler {locked_version} from Gemfile.lock")
+                self.command_runner.run_checked(
+                    ["gem", "install", "-N", "bundler", "-v", locked_version],
+                    env=env,
+                    cwd=str(cwd),
+                    should_stop=should_cancel,
+                )
+            return locked_version
+
         installed = self.command_runner.run(
             ["gem", "list", "-i", "bundler"],
             env=env,
@@ -282,22 +341,36 @@ class SetupExecutor:
                 cwd=str(cwd),
                 should_stop=should_cancel,
             )
+        return None
 
-    def _bundle_install(self, cwd: Path, env: Dict[str, str], build_id: str, log, should_cancel=None) -> None:
+    def _bundle_install(
+        self,
+        cwd: Path,
+        env: Dict[str, str],
+        build_id: str,
+        log,
+        bundler_version: str | None = None,
+        should_cancel=None,
+    ) -> None:
         bundle_path = str(Path(env["GEM_HOME"]) / "bundle")
+        bundle_command = self._bundle_command(bundler_version, "config", "set", "--local", "path", bundle_path)
         self.command_runner.run_checked(
-            ["bundle", "config", "set", "--local", "path", bundle_path],
+            bundle_command,
             env=env,
             cwd=str(cwd),
             should_stop=should_cancel,
         )
         log(f"[{build_id}] 📦 Installing Ruby bundle in {cwd.name}")
-        result = self.command_runner.run_checked(
-            ["bundle", "install"],
-            env=env,
-            cwd=str(cwd),
-            should_stop=should_cancel,
-        )
+        install_command = self._bundle_command(bundler_version, "install")
+        try:
+            result = self.command_runner.run_checked(
+                install_command,
+                env=env,
+                cwd=str(cwd),
+                should_stop=should_cancel,
+            )
+        except CommandExecutionError as exc:
+            self._raise_bundle_install_error(cwd, env, exc)
         for line in result.stdout.splitlines():
             if line.strip():
                 log(f"[{build_id}][SETUP] {line.strip()}")
@@ -336,6 +409,162 @@ class SetupExecutor:
             cwd=str(cwd),
             should_stop=should_cancel,
         )
+
+    def _resolve_requested_ruby_version(self, cwd: Path, env: Dict[str, str]) -> tuple[str | None, str | None]:
+        ruby_version_file = cwd / ".ruby-version"
+        if ruby_version_file.exists():
+            version = ruby_version_file.read_text(encoding="utf-8").strip()
+            if version:
+                return version, ".ruby-version"
+
+        tool_versions_file = cwd / ".tool-versions"
+        if tool_versions_file.exists():
+            for line in tool_versions_file.read_text(encoding="utf-8").splitlines():
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                if stripped.startswith("ruby "):
+                    _, version = stripped.split(None, 1)
+                    resolved = version.strip() or None
+                    return resolved, ".tool-versions"
+
+        lockfile_version = self._parse_lockfile_ruby_version(cwd)
+        if lockfile_version:
+            return lockfile_version, "Gemfile.lock"
+
+        configured_version = env.get("RUBY_VERSION") or os.environ.get("RUBY_VERSION")
+        if configured_version:
+            return configured_version.strip(), "RUBY_VERSION"
+        return None, None
+
+    def _parse_lockfile_bundler_version(self, cwd: Path) -> str | None:
+        lockfile = cwd / "Gemfile.lock"
+        if not lockfile.exists():
+            return None
+
+        lines = lockfile.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if line.strip() != "BUNDLED WITH":
+                continue
+            for candidate in lines[index + 1:]:
+                stripped = candidate.strip()
+                if stripped:
+                    return stripped
+        return None
+
+    def _parse_lockfile_ruby_version(self, cwd: Path) -> str | None:
+        lockfile = cwd / "Gemfile.lock"
+        if not lockfile.exists():
+            return None
+
+        lines = lockfile.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if line.strip() != "RUBY VERSION":
+                continue
+            for candidate in lines[index + 1:]:
+                stripped = candidate.strip()
+                if not stripped:
+                    continue
+                match = self._VERSION_PATTERN.search(stripped)
+                return match.group(1) if match else None
+        return None
+
+    def _prepend_rbenv_to_path(self, env: Dict[str, str]) -> None:
+        rbenv_root = Path(os.environ.get("RBENV_ROOT", Path.home() / ".rbenv")).expanduser()
+        path_entries = env.get("PATH", "").split(":") if env.get("PATH") else []
+        additions = [str(rbenv_root / "shims"), str(rbenv_root / "bin")]
+        merged: list[str] = []
+        for entry in additions + path_entries:
+            if entry and entry not in merged:
+                merged.append(entry)
+        env["PATH"] = ":".join(merged)
+
+    def _select_ruby_version(
+        self,
+        cwd: Path,
+        env: Dict[str, str],
+        requested_ruby: str,
+        requested_source: str,
+        build_id: str,
+        log,
+        should_cancel=None,
+    ) -> str | None:
+        rbenv_exists = self.command_runner.run(
+            ["rbenv", "versions", "--bare"],
+            env=env,
+            cwd=str(cwd),
+            check=False,
+            should_stop=should_cancel,
+        )
+        if rbenv_exists.returncode != 0:
+            log(f"[{build_id}] ⚠️ rbenv not available, continuing with system Ruby")
+            return None
+
+        installed_versions = {line.strip() for line in rbenv_exists.stdout.splitlines() if line.strip()}
+        if requested_ruby in installed_versions:
+            return requested_ruby
+
+        if requested_source in {"Gemfile.lock", "RUBY_VERSION"}:
+            compatible_versions = sorted(
+                (version for version in installed_versions if self._compare_versions(version, requested_ruby) >= 0),
+                key=self._version_sort_key,
+            )
+            if compatible_versions:
+                selected = compatible_versions[0]
+                log(f"[{build_id}] 💎 Using compatible installed Ruby {selected} for {requested_source} requirement {requested_ruby}+")
+                return selected
+
+        raise RuntimeError(
+            f"Requested Ruby {requested_ruby} from {requested_source} is not installed in rbenv. "
+            f"Installed versions: {', '.join(sorted(installed_versions)) or 'none'}"
+        )
+
+    def _current_ruby_version(self, cwd: Path, env: Dict[str, str], should_cancel=None) -> str | None:
+        result = self.command_runner.run(
+            ["ruby", "-e", "print RUBY_VERSION"],
+            env=env,
+            cwd=str(cwd),
+            check=False,
+            should_stop=should_cancel,
+        )
+        version = result.stdout.strip()
+        return version or None
+
+    def _bundle_command(self, bundler_version: str | None, *args: str) -> list[str]:
+        if bundler_version:
+            return ["bundle", f"_{bundler_version}_", *args]
+        return ["bundle", *args]
+
+    def _raise_bundle_install_error(
+        self,
+        cwd: Path,
+        env: Dict[str, str],
+        exc: CommandExecutionError,
+    ) -> None:
+        ruby_requirement = re.search(r"requires Ruby version >=\s*([0-9.]+)", exc.output, re.IGNORECASE)
+        if ruby_requirement:
+            required = ruby_requirement.group(1)
+            current = self._current_ruby_version(cwd, env) or "unknown"
+            raise RuntimeError(
+                f"bundle install requires Ruby {required}+ but active Ruby is {current}. "
+                "Install a newer Ruby with rbenv and set RUBY_VERSION, .ruby-version, or .tool-versions."
+            ) from exc
+        raise exc
+
+    def _compare_versions(self, left: str, right: str) -> int:
+        left_parts = [int(part) for part in left.split(".")]
+        right_parts = [int(part) for part in right.split(".")]
+        size = max(len(left_parts), len(right_parts))
+        left_parts.extend([0] * (size - len(left_parts)))
+        right_parts.extend([0] * (size - len(right_parts)))
+        if left_parts < right_parts:
+            return -1
+        if left_parts > right_parts:
+            return 1
+        return 0
+
+    def _version_sort_key(self, version: str) -> tuple[int, ...]:
+        return tuple(int(part) for part in version.split("."))
 
     def _install_fastlane_plugins(self, ios_dir: Path, env: Dict[str, str], build_id: str, log, should_cancel=None) -> None:
         pluginfile = ios_dir / "fastlane" / "Pluginfile"

--- a/tests/test_setup_executor.py
+++ b/tests/test_setup_executor.py
@@ -19,15 +19,15 @@ class FakeCommandRunner:
             CompletedCommand(args=command, returncode=returncode, stdout=stdout)
         )
 
-    def run(self, command, *, env, cwd, check=True):
+    def run(self, command, *, env, cwd, check=True, should_stop=None):
         self.calls.append(tuple(command))
         queue = self.responses.get(tuple(command), [])
         if queue:
             return queue.pop(0)
         return CompletedCommand(args=list(command), returncode=0, stdout="")
 
-    def run_checked(self, command, *, env, cwd):
-        result = self.run(command, env=env, cwd=cwd, check=True)
+    def run_checked(self, command, *, env, cwd, should_stop=None):
+        result = self.run(command, env=env, cwd=cwd, check=True, should_stop=should_stop)
         if result.returncode != 0:
             raise RuntimeError(f"unexpected failure for {' '.join(command)}")
         return result
@@ -100,16 +100,29 @@ class SetupExecutorTests(unittest.TestCase):
         executor = SetupExecutor(runner)
         logs: list[str] = []
 
+        runner.add_response(["rbenv", "versions", "--bare"], stdout="3.1.0\n3.2.0\n3.3.9\n")
+        runner.add_response(["ruby", "-e", "print RUBY_VERSION"], stdout="3.2.0")
         runner.add_response(["gem", "list", "-i", "cocoapods", "-v", "1.16.2"], returncode=0)
-        runner.add_response(["gem", "list", "-i", "bundler"], returncode=0)
-        runner.add_response(["bundle", "config", "set", "--local", "path", "/tmp/gems/bundle"])
-        runner.add_response(["bundle", "install"], stdout="bundle ok")
+        runner.add_response(["gem", "list", "-i", "bundler", "-v", "2.7.2"], returncode=0)
+        runner.add_response(["bundle", "_2.7.2_", "config", "set", "--local", "path", "/tmp/gems/bundle"])
+        runner.add_response(["bundle", "_2.7.2_", "install"], stdout="bundle ok")
 
         with tempfile.TemporaryDirectory() as tmp:
             repo_dir = Path(tmp) / "repo"
             ios_dir = repo_dir / "ios"
             ios_dir.mkdir(parents=True)
             (ios_dir / "Gemfile").write_text("source 'https://rubygems.org'\n", encoding="utf-8")
+            (ios_dir / "Gemfile.lock").write_text(
+                "GEM\n"
+                "  specs:\n"
+                "\n"
+                "RUBY VERSION\n"
+                "   ruby 3.2.0p0\n"
+                "\n"
+                "BUNDLED WITH\n"
+                "   2.7.2\n",
+                encoding="utf-8",
+            )
 
             executor.prepare_platform_toolchain(
                 build_id="build-ios",
@@ -120,9 +133,79 @@ class SetupExecutorTests(unittest.TestCase):
             )
 
         self.assertIn(("gem", "list", "-i", "cocoapods", "-v", "1.16.2"), runner.calls)
-        self.assertIn(("bundle", "config", "set", "--local", "path", "/tmp/gems/bundle"), runner.calls)
-        self.assertIn(("bundle", "install"), runner.calls)
+        self.assertIn(("gem", "list", "-i", "bundler", "-v", "2.7.2"), runner.calls)
+        self.assertIn(("bundle", "_2.7.2_", "config", "set", "--local", "path", "/tmp/gems/bundle"), runner.calls)
+        self.assertIn(("bundle", "_2.7.2_", "install"), runner.calls)
         self.assertTrue(any("Installing Ruby bundle" in line for line in logs))
+
+    def test_prepare_android_toolchain_uses_ruby_version_fallback(self) -> None:
+        runner = FakeCommandRunner()
+        executor = SetupExecutor(runner)
+        logs: list[str] = []
+
+        runner.add_response(["rbenv", "versions", "--bare"], stdout="3.1.0\n3.3.9\n")
+        runner.add_response(["ruby", "-e", "print RUBY_VERSION"], stdout="3.3.9")
+        runner.add_response(["gem", "list", "-i", "bundler", "-v", "2.7.2"], returncode=0)
+        runner.add_response(["bundle", "_2.7.2_", "config", "set", "--local", "path", "/tmp/gems/bundle"])
+        runner.add_response(["bundle", "_2.7.2_", "install"], stdout="bundle ok")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_dir = Path(tmp) / "repo"
+            android_dir = repo_dir / "android"
+            android_dir.mkdir(parents=True)
+            (android_dir / "Gemfile").write_text("source 'https://rubygems.org'\n", encoding="utf-8")
+            (android_dir / "Gemfile.lock").write_text(
+                "GEM\n"
+                "  specs:\n"
+                "\n"
+                "BUNDLED WITH\n"
+                "   2.7.2\n",
+                encoding="utf-8",
+            )
+
+            executor.prepare_platform_toolchain(
+                build_id="build-android",
+                platform="android",
+                repo_dir=str(repo_dir),
+                env={"GEM_HOME": "/tmp/gems", "RUBY_VERSION": "3.2.0"},
+                log=logs.append,
+            )
+
+        self.assertIn(("bundle", "_2.7.2_", "install"), runner.calls)
+        self.assertTrue(any("Using compatible installed Ruby 3.3.9 for RUBY_VERSION requirement 3.2.0+" in line for line in logs))
+
+    def test_prepare_android_toolchain_fails_when_lockfile_requires_newer_ruby(self) -> None:
+        runner = FakeCommandRunner()
+        executor = SetupExecutor(runner)
+
+        runner.add_response(["rbenv", "versions", "--bare"], stdout="3.1.0\n3.2.0\n")
+        runner.add_response(["ruby", "-e", "print RUBY_VERSION"], stdout="3.1.0")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_dir = Path(tmp) / "repo"
+            android_dir = repo_dir / "android"
+            android_dir.mkdir(parents=True)
+            (android_dir / "Gemfile").write_text("source 'https://rubygems.org'\n", encoding="utf-8")
+            (android_dir / "Gemfile.lock").write_text(
+                "GEM\n"
+                "  specs:\n"
+                "\n"
+                "RUBY VERSION\n"
+                "   ruby 3.2.0p0\n"
+                "\n"
+                "BUNDLED WITH\n"
+                "   2.7.2\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "Gemfile.lock requires Ruby 3.2.0\\+ but active Ruby is 3.1.0"):
+                executor.prepare_platform_toolchain(
+                    build_id="build-android",
+                    platform="android",
+                    repo_dir=str(repo_dir),
+                    env={"GEM_HOME": "/tmp/gems"},
+                    log=lambda _: None,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약
- `Gemfile.lock`의 `BUNDLED WITH`와 `RUBY VERSION`을 읽어 Android/iOS toolchain 준비 단계에서 필요한 Bundler/Ruby 요구사항을 먼저 맞추도록 수정했습니다.
- 빌드 격리 환경의 `RUBY_VERSION` fallback을 `3.2.0`으로 고정해, lockfile 정보가 부족한 경우에도 Ruby 3.1로 내려앉지 않도록 했습니다.
- `rbenv`에 exact version이 없더라도 `Gemfile.lock` 또는 `RUBY_VERSION` 기준으로 호환 가능한 상위 Ruby가 설치되어 있으면 그 버전을 선택하도록 보강했습니다.
- 관련 테스트와 `.env`/README 문서를 함께 업데이트했습니다.

## 테스트 / 검증
- `python3 -m compileall src tests`
- `/Users/seunghwanly/Documents/local-flutter-cicd-server/venv/bin/python -m unittest tests.test_setup_executor`

## 주의사항 / 후속 작업
- 빌드 머신에는 여전히 `rbenv` 기준으로 Ruby 3.2.0 이상이 설치되어 있어야 합니다.
- 이번 변경은 `main` 기준 새 브랜치에서 작업했으며, Ruby/Bundler 호환성 관련 파일만 포함했습니다.
- 전체 테스트 스위트는 돌리지 않았고, 이번 범위에 직접 관련된 `setup_executor` 테스트만 검증했습니다.