### PR TITLE
fix: 대시보드 스텝 로그 스크롤 유지

### DIFF
--- a/src/api/dashboard.html
+++ b/src/api/dashboard.html
@@ -813,19 +813,24 @@
             return '아직 실행되지 않음';
         };
 
-        const renderStageLogs = (logs) => {
+        const getStageKey = (stage) => String(stage?.name || 'unknown');
+
+        const renderStageLogs = (logs, stageKey) => {
             if (!logs || !logs.length) {
                 return '<div class="stage-log-empty">이 스텝에 기록된 로그가 아직 없습니다.</div>';
             }
-            return `<div class="stage-log-list">${logs.map(formatLogLine).join('')}</div>`;
+            return `<div class="stage-log-list" data-stage-key="${escapeHtml(stageKey)}">${logs.map(formatLogLine).join('')}</div>`;
         };
 
-        const renderStageItem = (stage) => {
-            const isOpen = stage.status === 'running' || stage.status === 'failed';
+        const renderStageItem = (stage, preservedState = null) => {
+            const stageKey = getStageKey(stage);
+            const isOpen = preservedState?.hasAccordions
+                ? preservedState.openStageKeys.includes(stageKey)
+                : (stage.status === 'running' || stage.status === 'failed');
             const logCount = Array.isArray(stage.logs) ? stage.logs.length : 0;
             return `
                 <div class="stage-item">
-                    <details class="stage-accordion" ${isOpen ? 'open' : ''}>
+                    <details class="stage-accordion" data-stage-key="${escapeHtml(stageKey)}" ${isOpen ? 'open' : ''}>
                         <summary class="stage-summary">
                             <div class="stage-top">
                                 <div>
@@ -844,7 +849,7 @@
                         </summary>
                         <div class="stage-log-panel">
                             <div class="stage-log-title">Step Logs</div>
-                            ${renderStageLogs(stage.logs)}
+                            ${renderStageLogs(stage.logs, stageKey)}
                         </div>
                     </details>
                 </div>
@@ -880,6 +885,7 @@
         let modalPollingInterval = null;
         let currentModalBuildId = null;
         let cancelInFlight = new Set();
+        let modalStageState = null;
 
         const setConnectionState = (state, label) => {
             const dot = document.getElementById('connection-dot');
@@ -932,6 +938,42 @@
             const container = document.getElementById('modal-cancel-action');
             if (!container) return;
             container.innerHTML = getCancelButtonHtml(buildId, status);
+        };
+
+        const captureModalStageState = () => {
+            const modalBody = document.querySelector('#log-modal .modal-body');
+            const stageContainer = document.getElementById('modal-stages');
+            if (!modalBody || !stageContainer) return null;
+
+            const accordions = Array.from(stageContainer.querySelectorAll('.stage-accordion'));
+
+            return {
+                hasAccordions: accordions.length > 0,
+                modalBodyScrollTop: modalBody.scrollTop,
+                openStageKeys: accordions
+                    .filter((element) => element.open)
+                    .map((element) => element.dataset.stageKey),
+                stageLogScrollTop: Object.fromEntries(
+                    Array.from(stageContainer.querySelectorAll('.stage-log-list'))
+                        .map((element) => [element.dataset.stageKey, element.scrollTop])
+                ),
+            };
+        };
+
+        const restoreModalStageState = (state) => {
+            if (!state) return;
+
+            const modalBody = document.querySelector('#log-modal .modal-body');
+            if (modalBody) {
+                modalBody.scrollTop = state.modalBodyScrollTop || 0;
+            }
+
+            Object.entries(state.stageLogScrollTop || {}).forEach(([stageKey, scrollTop]) => {
+                const logList = document.querySelector(`.stage-log-list[data-stage-key="${stageKey}"]`);
+                if (logList) {
+                    logList.scrollTop = scrollTop;
+                }
+            });
         };
 
         const fetchDiagnostics = async () => {
@@ -1087,9 +1129,11 @@
 
             const stageContainer = document.getElementById('modal-stages');
             const stages = data.stages || [];
+            modalStageState = captureModalStageState();
             stageContainer.innerHTML = stages.length
-                ? stages.map(renderStageItem).join('')
+                ? stages.map((stage) => renderStageItem(stage, modalStageState)).join('')
                 : '<div class="stage-item">현재 실행된 파이프라인 스테이지가 없습니다.</div>';
+            restoreModalStageState(modalStageState);
             
             const logContainer = document.getElementById('modal-logs');
             if (data.logs && data.logs.length > 0) {
@@ -1114,6 +1158,7 @@
 
         window.openModal = async (buildId) => {
             currentModalBuildId = buildId;
+            modalStageState = null;
             const overlay = document.getElementById('log-modal');
             const buildSummary = currentBuilds[buildId] || {};
             
@@ -1135,6 +1180,7 @@
         window.closeModal = () => {
             document.getElementById('log-modal').classList.remove('active');
             document.getElementById('modal-cancel-action').innerHTML = '';
+            modalStageState = null;
             if (modalPollingInterval) {
                 clearInterval(modalPollingInterval);
                 modalPollingInterval = null;


### PR DESCRIPTION
## 변경 요약
- 모달 자동 갱신 시 스테이지 아코디언의 열림 상태를 유지하도록 수정했습니다.
- 각 스텝 로그 영역과 모달 본문 스크롤 위치를 저장 후 복원하도록 수정했습니다.
- 첫 렌더에서는 기존 동작처럼 실행 중/실패 스텝을 기본으로 펼치도록 유지했습니다.

## 테스트 / 검증
- `make doctor` 실행 시 worktree에 `venv`가 없어 실패했습니다.
- 대신 `python3 -m compileall src` 실행
- `zsh -n action/1_ios.sh action/1_android.sh local_run.sh` 실행

## 주의사항
- 스테이지 키는 현재 `stage.name` 기준으로 복원합니다.
- 동일한 이름의 스테이지가 반복 생성되는 구조가 생기면 키 전략을 더 구체화해야 합니다.