### PR TITLE
fix: 안드로이드 shorebird 패치 캐시 아키텍처 복구

### DIFF
--- a/src/application/build_environment.py
+++ b/src/application/build_environment.py
@@ -42,6 +42,7 @@ class BuildEnvironmentAssembler:
                 "LOCAL_DIR": isolated["repo_dir"],
                 "BRANCH_NAME": job.branch_name,
                 "FLAVOR": job.flavor,
+                "TRIGGER_SOURCE": job.trigger_source,
                 "FASTLANE_LANE": fastlane_lane,
                 "DATADOG_API_KEY": os.environ.get("DATADOG_API_KEY", ""),
                 "GYM_DERIVED_DATA_PATH": isolated["deriveddata_cache_dir"],

--- a/src/infrastructure/setup_executor.py
+++ b/src/infrastructure/setup_executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import platform
 import re
 import shutil
 from pathlib import Path
@@ -265,10 +266,12 @@ class SetupExecutor:
         if (android_dir / "Gemfile").exists():
             bundler_version = self._ensure_bundler(android_dir, env, build_id, log, should_cancel=should_cancel)
             self._bundle_install(android_dir, env, build_id, log, bundler_version=bundler_version, should_cancel=should_cancel)
+            self._repair_incompatible_shorebird_patch_artifact(android_dir, env, build_id, log, should_cancel=should_cancel)
             return
 
         self._ensure_digest_crc(android_dir, env, build_id, log, should_cancel=should_cancel)
         self._ensure_gem("fastlane", env.get("FASTLANE_VERSION"), android_dir, env, build_id, log, should_cancel=should_cancel)
+        self._repair_incompatible_shorebird_patch_artifact(android_dir, env, build_id, log, should_cancel=should_cancel)
 
     def _configure_ruby_environment(self, cwd: Path, env: Dict[str, str], build_id: str, log, should_cancel=None) -> None:
         self._prepend_rbenv_to_path(env)
@@ -621,3 +624,45 @@ class SetupExecutor:
                 last_error = exc
         if last_error is not None:
             raise last_error
+
+    def _repair_incompatible_shorebird_patch_artifact(
+        self,
+        cwd: Path,
+        env: Dict[str, str],
+        build_id: str,
+        log,
+        should_cancel=None,
+    ) -> None:
+        if env.get("TRIGGER_SOURCE") not in {"shorebird", "shorebird_manual"}:
+            return
+
+        host_arch = platform.machine().lower()
+        if host_arch not in {"arm64", "aarch64"}:
+            return
+
+        shorebird_home = Path(env.get("HOME", str(Path.home()))).expanduser() / ".shorebird"
+        patch_dir = shorebird_home / "bin" / "cache" / "artifacts" / "patch"
+        patch_binary = patch_dir / "patch"
+        if not patch_binary.exists():
+            return
+
+        result = self.command_runner.run(
+            ["file", str(patch_binary)],
+            env=env,
+            cwd=str(cwd),
+            check=False,
+            should_stop=should_cancel,
+        )
+        if result.returncode != 0:
+            log(f"[{build_id}] ⚠️ Unable to inspect Shorebird patch artifact architecture")
+            return
+
+        description = result.stdout.lower()
+        if "x86_64" not in description or "arm64" in description:
+            return
+
+        log(
+            f"[{build_id}] 🧹 Removing incompatible Shorebird patch artifact cache "
+            f"for host architecture {host_arch}: {patch_binary}"
+        )
+        shutil.rmtree(patch_dir, ignore_errors=True)

--- a/tests/test_build_environment.py
+++ b/tests/test_build_environment.py
@@ -70,6 +70,7 @@ class BuildEnvironmentAssemblerTests(unittest.TestCase):
                 )
 
         self.assertEqual("patch_prod", runtime.env["FASTLANE_LANE"])
+        self.assertEqual("shorebird_manual", runtime.env["TRIGGER_SOURCE"])
         self.assertTrue(any("Shorebird patch config" in line for line in logs))
         self.assertEqual("release/2.2.1-hotfix", repo_manager.calls[0]["branch_name"])
 
@@ -154,6 +155,7 @@ class BuildEnvironmentAssemblerTests(unittest.TestCase):
             )
 
         self.assertEqual("deploy_stage", runtime.env["FASTLANE_LANE"])
+        self.assertEqual("manual", runtime.env["TRIGGER_SOURCE"])
         self.assertNotIn("SHOREBIRD_RELEASE_VERSION", runtime.env)
 
 

--- a/tests/test_setup_executor.py
+++ b/tests/test_setup_executor.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from collections import defaultdict
 from pathlib import Path
+from unittest.mock import patch
 
 from src.infrastructure.command_runner import CompletedCommand
 from src.infrastructure.setup_executor import SetupExecutor
@@ -206,6 +207,58 @@ class SetupExecutorTests(unittest.TestCase):
                     env={"GEM_HOME": "/tmp/gems"},
                     log=lambda _: None,
                 )
+
+    def test_repair_incompatible_shorebird_patch_artifact_on_arm64(self) -> None:
+        runner = FakeCommandRunner()
+        executor = SetupExecutor(runner)
+        logs: list[str] = []
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home_dir = Path(tmp)
+            patch_dir = home_dir / ".shorebird" / "bin" / "cache" / "artifacts" / "patch"
+            patch_dir.mkdir(parents=True)
+            patch_binary = patch_dir / "patch"
+            patch_binary.write_text("binary", encoding="utf-8")
+            runner.add_response(
+                ["file", str(patch_binary)],
+                stdout=f"{patch_binary}: Mach-O 64-bit executable x86_64\n",
+            )
+
+            with patch("src.infrastructure.setup_executor.platform.machine", return_value="arm64"):
+                executor._repair_incompatible_shorebird_patch_artifact(
+                    cwd=home_dir,
+                    env={"HOME": str(home_dir), "TRIGGER_SOURCE": "shorebird_manual"},
+                    build_id="build-shorebird",
+                    log=logs.append,
+                )
+
+            self.assertFalse(patch_dir.exists())
+
+        self.assertIn(("file", str(patch_binary)), runner.calls)
+        self.assertTrue(any("Removing incompatible Shorebird patch artifact cache" in line for line in logs))
+
+    def test_repair_shorebird_patch_artifact_skips_for_non_shorebird_build(self) -> None:
+        runner = FakeCommandRunner()
+        executor = SetupExecutor(runner)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            home_dir = Path(tmp)
+            patch_dir = home_dir / ".shorebird" / "bin" / "cache" / "artifacts" / "patch"
+            patch_dir.mkdir(parents=True)
+            patch_binary = patch_dir / "patch"
+            patch_binary.write_text("binary", encoding="utf-8")
+
+            with patch("src.infrastructure.setup_executor.platform.machine", return_value="arm64"):
+                executor._repair_incompatible_shorebird_patch_artifact(
+                    cwd=home_dir,
+                    env={"HOME": str(home_dir), "TRIGGER_SOURCE": "manual"},
+                    build_id="build-manual",
+                    log=lambda _: None,
+                )
+
+            self.assertTrue(patch_binary.exists())
+
+        self.assertEqual([], runner.calls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약
- shorebird 빌드일 때 `TRIGGER_SOURCE`를 실행 환경으로 전달하도록 수정했습니다.
- Apple Silicon 호스트에서 `~/.shorebird/bin/cache/artifacts/patch/patch`가 `x86_64` 단일 바이너리면 Android toolchain 준비 단계에서 해당 캐시를 제거하도록 추가했습니다.
- 다음 Shorebird patch 실행 시 patch artifact가 현재 호스트 아키텍처에 맞게 다시 다운로드되도록 했습니다.

## 원인
- 실제 호스트는 `arm64`인데 Shorebird patch 캐시 바이너리가 `x86_64`로 남아 있었습니다.
- Shorebird CLI를 최신으로 올린 뒤에도 patch artifact는 그대로 `x86_64`여서 `Bad CPU type in executable`가 재발 가능한 상태였습니다.

## 테스트 / 검증
- `/Users/seunghwanly/Documents/local-flutter-cicd-server/venv/bin/python -m unittest tests.test_setup_executor tests.test_build_environment`
- `python3 -m compileall src`
- `bash -n action/1_android.sh action/1_ios.sh local_run.sh scripts/restart_local_server.sh`

## 주의사항
- 현재 수정은 Android Shorebird patch 빌드 전에 호스트 캐시를 점검하는 방어 로직입니다.
- 동일 이슈가 iOS patch 경로에서도 재현되면 같은 복구를 iOS toolchain 준비 단계에도 확장하면 됩니다.