### PR TITLE
fix: Shorebird iOS CocoaPods 충돌 수정

### DIFF
--- a/action/1_ios.sh
+++ b/action/1_ios.sh
@@ -62,6 +62,16 @@ PATCH_MODE=false
 if [[ "$FASTLANE_LANE" == patch_* ]]; then
     PATCH_MODE=true
 fi
+IOS_USE_BUNDLER="${IOS_USE_BUNDLER:-}"
+if [ -z "$IOS_USE_BUNDLER" ]; then
+    if [ "$PATCH_MODE" = true ]; then
+        IOS_USE_BUNDLER=false
+    elif [ "$USE_BUNDLER" = true ]; then
+        IOS_USE_BUNDLER=true
+    else
+        IOS_USE_BUNDLER=false
+    fi
+fi
 
 # # Flutter 아티팩트 준비
 # echo "📦 Ensuring flutter artifacts..."
@@ -99,7 +109,7 @@ echo "📦 CocoaPods version:"
 if [ -n "$COCOAPODS_VERSION" ]; then
     echo "📦 Executing CocoaPods via: pod _${COCOAPODS_VERSION}_"
     pod "_${COCOAPODS_VERSION}_" --version
-elif [ "$USE_BUNDLER" = true ]; then
+elif [ "$IOS_USE_BUNDLER" = true ]; then
     echo "📦 Executing CocoaPods via: bundle exec pod"
     bundle exec pod --version
 else
@@ -116,7 +126,7 @@ if [ -n "$COCOAPODS_VERSION" ]; then
         echo "⚠️ pod install failed, retrying with --repo-update"
         pod "_${COCOAPODS_VERSION}_" install --repo-update
     fi
-elif [ "$USE_BUNDLER" = true ]; then
+elif [ "$IOS_USE_BUNDLER" = true ]; then
     if bundle exec pod install; then
         true
     else
@@ -145,7 +155,7 @@ fi
 # fi
 
 # Fastlane 명령 구성
-if [ "$USE_BUNDLER" = true ]; then
+if [ "$IOS_USE_BUNDLER" = true ]; then
     FASTLANE_CMD=(bundle exec fastlane "$FASTLANE_LANE")
 else
     FASTLANE_CMD=(fvm exec fastlane "$FASTLANE_LANE")
@@ -187,6 +197,7 @@ export GYM_XCARCHIVE_PATH="$DERIVED_DATA_PATH/Archives"
 
 # Fastlane 실행
 echo "🚀 Running: ${FASTLANE_CMD[*]}"
+echo "📦 Using Bundler for Ruby tools: $IOS_USE_BUNDLER"
 echo "🏗️ Using DerivedData path: $DERIVED_DATA_PATH"
 echo "🏗️ GYM_DERIVED_DATA_PATH: $GYM_DERIVED_DATA_PATH"
 echo "🏗️ GYM_XCARCHIVE_PATH: $GYM_XCARCHIVE_PATH"

--- a/src/application/build_environment.py
+++ b/src/application/build_environment.py
@@ -35,6 +35,7 @@ class BuildEnvironmentAssembler:
                 "FLAVOR": job.flavor,
                 "TRIGGER_SOURCE": job.trigger_source,
                 "FASTLANE_LANE": fastlane_lane,
+                "IOS_USE_BUNDLER": self._resolve_ios_use_bundler(job),
                 "DATADOG_API_KEY": os.environ.get("DATADOG_API_KEY", ""),
                 "GYM_DERIVED_DATA_PATH": isolated["deriveddata_cache_dir"],
                 "GYM_XCARCHIVE_PATH": os.path.join(isolated["deriveddata_cache_dir"], "Archives"),
@@ -128,3 +129,8 @@ class BuildEnvironmentAssembler:
         if job.trigger_source in {"shorebird", "shorebird_manual"}:
             return os.environ.get(f"SHOREBIRD_{job.flavor.upper()}_FASTLANE_LANE", f"patch_{job.flavor}")
         return os.environ.get(f"{job.flavor.upper()}_FASTLANE_LANE", "beta")
+
+    def _resolve_ios_use_bundler(self, job: BuildJob) -> str:
+        if job.platform in {"ios", "all"} and job.trigger_source in {"shorebird", "shorebird_manual"}:
+            return "false"
+        return "true"

--- a/src/application/build_orchestrator.py
+++ b/src/application/build_orchestrator.py
@@ -206,15 +206,15 @@ class BuildOrchestrator:
             return False
         commands = []
         if job.platform in {"all", "android"}:
-            commands.append(("android", self._build_command("action/1_android.sh"), runtime.build_env()))
+            commands.append(("android", self._build_command("action/1_android.sh")))
         if job.platform in {"all", "ios"}:
-            commands.append(("ios", self._build_command("action/1_ios.sh"), runtime.build_env()))
+            commands.append(("ios", self._build_command("action/1_ios.sh")))
         if not commands:
             self._log(job, f"[{job.build_id}] ❌ No build processes started")
             return False
 
         processes = []
-        for platform_name, command, command_env in commands:
+        for platform_name, command in commands:
             try:
                 preflight_stage = f"{platform_name}_preflight"
                 toolchain_stage = f"{platform_name}_toolchain_ready"
@@ -258,6 +258,7 @@ class BuildOrchestrator:
                 return False
             job.mark_stage_running(build_stage, f"{platform_name.title()} build started")
             self._log(job, f"[{job.build_id}] Starting {platform_name} build...")
+            command_env = runtime.build_env()
             process = self.command_runner.start(command, env=command_env, cwd=os.getcwd())
             job.processes[platform_name] = process
             processes.append((platform_name, process))

--- a/src/infrastructure/platform_toolchain.py
+++ b/src/infrastructure/platform_toolchain.py
@@ -275,6 +275,11 @@ class PlatformToolchainPreparer:
                 bundler_version=bundler_version,
                 should_cancel=should_cancel,
             )
+            if context.is_shorebird_patch():
+                self.ruby_toolchain.ensure_gem(
+                    "fastlane", context.env.get("FASTLANE_VERSION"), ios_dir, context.env, build_id, log, should_cancel=should_cancel
+                )
+                self.ruby_toolchain.install_fastlane_plugins(ios_dir, context.env, build_id, log, should_cancel=should_cancel)
             return
 
         self.ruby_toolchain.ensure_gem(

--- a/tests/test_build_environment.py
+++ b/tests/test_build_environment.py
@@ -75,6 +75,7 @@ class BuildEnvironmentAssemblerTests(unittest.TestCase):
                 )
 
         self.assertEqual("patch_prod", runtime.env["FASTLANE_LANE"])
+        self.assertEqual("false", runtime.env["IOS_USE_BUNDLER"])
         self.assertEqual("shorebird_manual", runtime.env["TRIGGER_SOURCE"])
         self.assertTrue(any("Shorebird patch config" in line for line in logs))
         self.assertEqual("release/2.2.1-hotfix", repo_manager.calls[0]["branch_name"])
@@ -121,6 +122,7 @@ class BuildEnvironmentAssemblerTests(unittest.TestCase):
             )
 
         self.assertEqual("custom_patch_stage", runtime.env["FASTLANE_LANE"])
+        self.assertEqual("false", runtime.env["IOS_USE_BUNDLER"])
 
     def test_regular_build_uses_flavor_lane(self) -> None:
         repo_manager = StubRepositoryWorkspaceManager()
@@ -160,6 +162,7 @@ class BuildEnvironmentAssemblerTests(unittest.TestCase):
             )
 
         self.assertEqual("deploy_stage", runtime.env["FASTLANE_LANE"])
+        self.assertEqual("true", runtime.env["IOS_USE_BUNDLER"])
         self.assertEqual("manual", runtime.env["TRIGGER_SOURCE"])
         self.assertNotIn("SHOREBIRD_RELEASE_VERSION", runtime.env)
 

--- a/tests/test_build_orchestrator.py
+++ b/tests/test_build_orchestrator.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import unittest
+
+from src.application.build_orchestrator import BuildOrchestrator
+from src.core import BuildRuntimeContext
+from src.domain import BuildJob, BuildRequestData
+
+
+class StubRepository:
+    def __init__(self) -> None:
+        self.jobs: dict[str, BuildJob] = {}
+
+    def save(self, job: BuildJob) -> None:
+        self.jobs[job.build_id] = job
+
+    def get(self, build_id: str):
+        return self.jobs.get(build_id)
+
+    def list_all(self):
+        return list(self.jobs.values())
+
+
+class StubSetupExecutor:
+    def run_setup(self, **kwargs) -> None:
+        return None
+
+    def prepare_platform_preflight(self, **kwargs) -> None:
+        return None
+
+    def prepare_platform_toolchain(self, *, context, **kwargs) -> None:
+        context.env["RBENV_VERSION"] = "3.2.0"
+        context.env["GEM_HOME"] = "/tmp/gems/ruby-3.2.0"
+        context.env["BUNDLE_PATH"] = "/tmp/gems/ruby-3.2.0/bundle"
+
+
+class FakeProcess:
+    def __init__(self) -> None:
+        self.returncode = 0
+
+
+class CapturingCommandRunner:
+    def __init__(self) -> None:
+        self.started_envs: list[dict[str, str]] = []
+
+    def start(self, command, *, env, cwd, line_buffered=False):
+        self.started_envs.append(dict(env))
+        return FakeProcess()
+
+    def wait(self, process) -> int:
+        return process.returncode
+
+    def iter_lines(self, process):
+        return iter(())
+
+    def terminate(self, process, *, kill_after_seconds: float = 5.0) -> None:
+        return None
+
+
+class BuildOrchestratorTests(unittest.TestCase):
+    def test_run_build_scripts_uses_toolchain_updated_runtime_env(self) -> None:
+        repository = StubRepository()
+        command_runner = CapturingCommandRunner()
+        orchestrator = BuildOrchestrator(
+            repository=repository,
+            validator=None,
+            version_resolver=None,
+            command_runner=command_runner,
+            config_diagnostics=None,
+            environment_assembler=None,
+            setup_executor=StubSetupExecutor(),
+            status_presenter=None,
+        )
+
+        request = BuildRequestData(
+            flavor="dev",
+            platform="ios",
+            trigger_source="shorebird_manual",
+            build_name="2.2.1",
+            build_number="693",
+            branch_name="release/2.2.1",
+        )
+        job = BuildJob.create("build-ios", request, request.branch_name or "develop", "queue-1")
+        runtime = BuildRuntimeContext(
+            env={},
+            repo_dir="/tmp/repo",
+            workspace="/tmp/workspace",
+            trigger_source=request.trigger_source,
+            build_name=request.build_name,
+            build_number=request.build_number,
+        )
+
+        success = orchestrator._run_build_scripts(job, runtime)
+
+        self.assertTrue(success)
+        self.assertEqual(1, len(command_runner.started_envs))
+        started_env = command_runner.started_envs[0]
+        self.assertEqual("3.2.0", started_env["RBENV_VERSION"])
+        self.assertEqual("/tmp/gems/ruby-3.2.0", started_env["GEM_HOME"])
+        self.assertEqual("/tmp/gems/ruby-3.2.0/bundle", started_env["BUNDLE_PATH"])
+        self.assertEqual("2.2.1", started_env["BUILD_NAME"])
+        self.assertEqual("693", started_env["BUILD_NUMBER"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_setup_executor.py
+++ b/tests/test_setup_executor.py
@@ -153,6 +153,59 @@ class SetupExecutorTests(unittest.TestCase):
         self.assertEqual("/tmp/gems/ruby-3.2.0", context.env["GEM_HOME"])
         self.assertEqual("/tmp/gems/ruby-3.2.0/bundle", context.env["BUNDLE_PATH"])
 
+    def test_prepare_ios_toolchain_prepares_standalone_fastlane_for_shorebird_patch(self) -> None:
+        runner = FakeCommandRunner()
+        executor = SetupExecutor(runner)
+
+        runner.add_response(["rbenv", "versions", "--bare"], stdout="3.2.0\n")
+        runner.add_response(["ruby", "-e", "print RUBY_VERSION"], stdout="3.2.0")
+        runner.add_response(["gem", "list", "-i", "cocoapods", "-v", "1.16.2"], returncode=0)
+        runner.add_response(["gem", "list", "-i", "bundler", "-v", "2.7.2"], returncode=0)
+        runner.add_response(["bundle", "_2.7.2_", "config", "set", "--local", "path", "/tmp/gems/ruby-3.2.0/bundle"])
+        runner.add_response(["bundle", "_2.7.2_", "install"], stdout="bundle ok")
+        runner.add_response(["gem", "list", "-i", "fastlane"], returncode=0)
+        runner.add_response(["gem", "list", "-i", "fastlane-plugin-shorebird"], returncode=0)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_dir = Path(tmp) / "repo"
+            ios_dir = repo_dir / "ios"
+            fastlane_dir = ios_dir / "fastlane"
+            fastlane_dir.mkdir(parents=True)
+            (ios_dir / "Gemfile").write_text("source 'https://rubygems.org'\n", encoding="utf-8")
+            (ios_dir / "Gemfile.lock").write_text(
+                "GEM\n"
+                "  specs:\n"
+                "\n"
+                "RUBY VERSION\n"
+                "   ruby 3.2.0p0\n"
+                "\n"
+                "BUNDLED WITH\n"
+                "   2.7.2\n",
+                encoding="utf-8",
+            )
+            (fastlane_dir / "Pluginfile").write_text(
+                "gem 'fastlane-plugin-shorebird'\n",
+                encoding="utf-8",
+            )
+
+            context = BuildRuntimeContext(
+                env={"GEM_HOME": "/tmp/gems", "COCOAPODS_VERSION": "1.16.2"},
+                repo_dir=str(repo_dir),
+                workspace=tmp,
+                trigger_source="shorebird_manual",
+            )
+
+            executor.prepare_platform_toolchain(
+                build_id="build-ios-shorebird",
+                platform="ios",
+                context=context,
+                log=lambda _: None,
+            )
+
+        self.assertIn(("bundle", "_2.7.2_", "install"), runner.calls)
+        self.assertIn(("gem", "list", "-i", "fastlane"), runner.calls)
+        self.assertIn(("gem", "list", "-i", "fastlane-plugin-shorebird"), runner.calls)
+
     def test_prepare_android_toolchain_uses_ruby_version_fallback(self) -> None:
         runner = FakeCommandRunner()
         executor = SetupExecutor(runner)


### PR DESCRIPTION
## 변경 요약
- Shorebird iOS patch 빌드에는 `IOS_USE_BUNDLER=false`를 주입해서 `bundle exec fastlane` 대신 standalone Fastlane/pod 경로를 사용하도록 변경했습니다.
- `ios/Gemfile`가 있는 프로젝트라도 Shorebird patch일 때는 standalone `fastlane` gem과 `fastlane` plugin gem을 추가로 준비하도록 iOS toolchain 준비 로직을 보강했습니다.
- 관련 회귀를 막기 위해 빌드 환경/설정 준비 테스트를 추가했습니다.

## 원인
- 기존에는 `ios/Gemfile`이 있으면 항상 Bundler 경로만 사용했습니다.
- Shorebird plugin이 그 상태에서 `flutter build ipa`를 다시 호출하면 Flutter가 plain `pod`를 확인하는 단계에서 Bundler 문맥과 충돌해 `CocoaPods is installed but broken`로 실패할 수 있었습니다.

## 검증
- `make doctor`
- `./venv/bin/python -m unittest tests.test_build_environment tests.test_setup_executor`

## 주의사항
- 일반 iOS Fastlane lane은 기존처럼 Bundler 경로를 유지합니다.
- 변경 범위는 Shorebird iOS patch 경로에 한정했습니다.