### PR TITLE
fix: iOS pod install 자동 판정으로 전환

### DIFF
--- a/action/1_ios.sh
+++ b/action/1_ios.sh
@@ -72,6 +72,56 @@ if [ -z "$IOS_USE_BUNDLER" ]; then
         IOS_USE_BUNDLER=false
     fi
 fi
+IOS_RUN_POD_INSTALL="${IOS_RUN_POD_INSTALL:-auto}"
+SHOULD_RUN_POD_INSTALL=false
+POD_INSTALL_REASONS=()
+
+mark_pod_install_required() {
+    SHOULD_RUN_POD_INSTALL=true
+    POD_INSTALL_REASONS+=("$1")
+}
+
+evaluate_auto_pod_install() {
+    if [ ! -f "Podfile.lock" ]; then
+        mark_pod_install_required "Podfile.lock missing"
+    fi
+    if [ ! -f "Pods/Manifest.lock" ]; then
+        mark_pod_install_required "Pods/Manifest.lock missing"
+    fi
+    if [ ! -d "Runner.xcworkspace" ]; then
+        mark_pod_install_required "Runner.xcworkspace missing"
+    fi
+    if [ ! -f "Flutter/Generated.xcconfig" ]; then
+        mark_pod_install_required "Flutter/Generated.xcconfig missing"
+    fi
+    if [ -f "Podfile.lock" ] && [ -f "Pods/Manifest.lock" ] && ! cmp -s "Podfile.lock" "Pods/Manifest.lock"; then
+        mark_pod_install_required "Podfile.lock and Pods/Manifest.lock differ"
+    fi
+    if [ -f "Podfile" ] && [ -f "Pods/Manifest.lock" ] && [ "Podfile" -nt "Pods/Manifest.lock" ]; then
+        mark_pod_install_required "Podfile is newer than Pods/Manifest.lock"
+    fi
+    if [ -f "../.flutter-plugins-dependencies" ] && { [ ! -f "Pods/Manifest.lock" ] || [ "../.flutter-plugins-dependencies" -nt "Pods/Manifest.lock" ]; }; then
+        mark_pod_install_required ".flutter-plugins-dependencies is newer than Pods/Manifest.lock"
+    fi
+    if [ "${IOS_FLUTTER_SDK_CHANGED:-false}" = "true" ]; then
+        mark_pod_install_required "Flutter SDK version changed since previous sync"
+    fi
+}
+
+case "$IOS_RUN_POD_INSTALL" in
+    true|TRUE|1|yes|YES)
+        mark_pod_install_required "forced by IOS_RUN_POD_INSTALL=$IOS_RUN_POD_INSTALL"
+        ;;
+    false|FALSE|0|no|NO)
+        ;;
+    auto|AUTO|"")
+        evaluate_auto_pod_install
+        ;;
+    *)
+        echo "⚠️ Unknown IOS_RUN_POD_INSTALL=$IOS_RUN_POD_INSTALL, falling back to auto detection"
+        evaluate_auto_pod_install
+        ;;
+esac
 
 # # Flutter 아티팩트 준비
 # echo "📦 Ensuring flutter artifacts..."
@@ -118,28 +168,35 @@ else
 fi
 
 # pod install 실행
-echo "📚 Running pod install..."
-if [ -n "$COCOAPODS_VERSION" ]; then
-    if pod "_${COCOAPODS_VERSION}_" install; then
-        true
+if [ "$SHOULD_RUN_POD_INSTALL" = true ]; then
+    echo "📚 Running pod install..."
+    printf '  • %s\n' "${POD_INSTALL_REASONS[@]}"
+
+    if [ -n "$COCOAPODS_VERSION" ]; then
+        POD_INSTALL_CMD=(pod "_${COCOAPODS_VERSION}_" install)
+    elif [ "$IOS_USE_BUNDLER" = true ]; then
+        POD_INSTALL_CMD=(bundle exec pod install)
     else
-        echo "⚠️ pod install failed, retrying with --repo-update"
-        pod "_${COCOAPODS_VERSION}_" install --repo-update
+        POD_INSTALL_CMD=(pod install)
     fi
-elif [ "$IOS_USE_BUNDLER" = true ]; then
-    if bundle exec pod install; then
-        true
+
+    POD_INSTALL_LOG="$(mktemp)"
+    if "${POD_INSTALL_CMD[@]}" >"$POD_INSTALL_LOG" 2>&1; then
+        cat "$POD_INSTALL_LOG"
     else
-        echo "⚠️ pod install failed, retrying with --repo-update"
-        bundle exec pod install --repo-update
+        cat "$POD_INSTALL_LOG"
+        if grep -Eiq "Unable to find a specification|could not find compatible versions|out-of-date source repos|Specs satisfying the" "$POD_INSTALL_LOG"; then
+            echo "⚠️ pod install failed with a spec resolution error, retrying with --repo-update"
+            "${POD_INSTALL_CMD[@]}" --repo-update
+        else
+            echo "❌ pod install failed without a repo update hint"
+            rm -f "$POD_INSTALL_LOG"
+            exit 1
+        fi
     fi
+    rm -f "$POD_INSTALL_LOG"
 else
-    if pod install; then
-        true
-    else
-        echo "⚠️ pod install failed, retrying with --repo-update"
-        pod install --repo-update
-    fi
+    echo "⏭️ Skipping pod install (IOS_RUN_POD_INSTALL=$IOS_RUN_POD_INSTALL, auto-detect found no changes)"
 fi
 
 # # Fastlane match (필요시)
@@ -198,6 +255,7 @@ export GYM_XCARCHIVE_PATH="$DERIVED_DATA_PATH/Archives"
 # Fastlane 실행
 echo "🚀 Running: ${FASTLANE_CMD[*]}"
 echo "📦 Using Bundler for Ruby tools: $IOS_USE_BUNDLER"
+echo "📚 Run pod install: $SHOULD_RUN_POD_INSTALL"
 echo "🏗️ Using DerivedData path: $DERIVED_DATA_PATH"
 echo "🏗️ GYM_DERIVED_DATA_PATH: $GYM_DERIVED_DATA_PATH"
 echo "🏗️ GYM_XCARCHIVE_PATH: $GYM_XCARCHIVE_PATH"

--- a/src/internal/application/build_environment.py
+++ b/src/internal/application/build_environment.py
@@ -36,6 +36,7 @@ class BuildEnvironmentAssembler:
                 "TRIGGER_SOURCE": job.trigger_source,
                 "FASTLANE_LANE": fastlane_lane,
                 "IOS_USE_BUNDLER": self._resolve_ios_use_bundler(job),
+                "IOS_RUN_POD_INSTALL": self._resolve_ios_run_pod_install(),
                 "DATADOG_API_KEY": os.environ.get("DATADOG_API_KEY", ""),
                 "GYM_DERIVED_DATA_PATH": isolated["deriveddata_cache_dir"],
                 "GYM_XCARCHIVE_PATH": os.path.join(isolated["deriveddata_cache_dir"], "Archives"),
@@ -55,6 +56,7 @@ class BuildEnvironmentAssembler:
             should_cancel=should_cancel,
         )
         env["LOCAL_DIR"] = prepared.repo_dir
+        env["IOS_FLUTTER_SDK_CHANGED"] = "true" if prepared.flutter_version_changed else "false"
         job.mark_stage_completed("repository_synced", f"Repository synchronized for {job.branch_name}")
         resolved_flutter_version = prepared.flutter_version
         if resolved_flutter_version:
@@ -134,3 +136,6 @@ class BuildEnvironmentAssembler:
         if job.platform in {"ios", "all"} and job.trigger_source in {"shorebird", "shorebird_manual"}:
             return "false"
         return "true"
+
+    def _resolve_ios_run_pod_install(self) -> str:
+        return os.environ.get("IOS_RUN_POD_INSTALL", "auto")

--- a/src/internal/infrastructure/repository_workspace.py
+++ b/src/internal/infrastructure/repository_workspace.py
@@ -22,11 +22,13 @@ class PreparedRepositoryResult:
         precache_ran: bool,
         repo_dir: str,
         workspace_lease: WorkspaceSlotLease | None,
+        flutter_version_changed: bool = False,
     ) -> None:
         self.flutter_version = flutter_version
         self.precache_ran = precache_ran
         self.repo_dir = repo_dir
         self.workspace_lease = workspace_lease
+        self.flutter_version_changed = flutter_version_changed
 
 
 class RepositoryWorkspaceManager:
@@ -116,6 +118,7 @@ class RepositoryWorkspaceManager:
                 precache_ran=precache_ran,
                 repo_dir=str(repo_path),
                 workspace_lease=workspace_lease,
+                flutter_version_changed=version_changed,
             )
         except Exception:
             workspace_lease.release()

--- a/tests/test_build_environment.py
+++ b/tests/test_build_environment.py
@@ -15,6 +15,7 @@ from src.internal.infrastructure.repository_workspace import PreparedRepositoryR
 class StubRepositoryWorkspaceManager:
     def __init__(self) -> None:
         self.calls = []
+        self.flutter_version_changed = False
 
     def prepare(self, **kwargs):
         self.calls.append(kwargs)
@@ -25,6 +26,7 @@ class StubRepositoryWorkspaceManager:
             precache_ran=False,
             repo_dir=str(repo_dir),
             workspace_lease=None,
+            flutter_version_changed=self.flutter_version_changed,
         )
 
 
@@ -76,6 +78,8 @@ class BuildEnvironmentAssemblerTests(unittest.TestCase):
 
         self.assertEqual("patch_prod", runtime.env["FASTLANE_LANE"])
         self.assertEqual("false", runtime.env["IOS_USE_BUNDLER"])
+        self.assertEqual("auto", runtime.env["IOS_RUN_POD_INSTALL"])
+        self.assertEqual("false", runtime.env["IOS_FLUTTER_SDK_CHANGED"])
         self.assertEqual("shorebird_manual", runtime.env["TRIGGER_SOURCE"])
         self.assertTrue(any("Shorebird patch config" in line for line in logs))
         self.assertEqual("release/2.2.1-hotfix", repo_manager.calls[0]["branch_name"])
@@ -123,6 +127,8 @@ class BuildEnvironmentAssemblerTests(unittest.TestCase):
 
         self.assertEqual("custom_patch_stage", runtime.env["FASTLANE_LANE"])
         self.assertEqual("false", runtime.env["IOS_USE_BUNDLER"])
+        self.assertEqual("auto", runtime.env["IOS_RUN_POD_INSTALL"])
+        self.assertEqual("false", runtime.env["IOS_FLUTTER_SDK_CHANGED"])
 
     def test_regular_build_uses_flavor_lane(self) -> None:
         repo_manager = StubRepositoryWorkspaceManager()
@@ -163,8 +169,94 @@ class BuildEnvironmentAssemblerTests(unittest.TestCase):
 
         self.assertEqual("deploy_stage", runtime.env["FASTLANE_LANE"])
         self.assertEqual("true", runtime.env["IOS_USE_BUNDLER"])
+        self.assertEqual("auto", runtime.env["IOS_RUN_POD_INSTALL"])
+        self.assertEqual("false", runtime.env["IOS_FLUTTER_SDK_CHANGED"])
         self.assertEqual("manual", runtime.env["TRIGGER_SOURCE"])
         self.assertNotIn("SHOREBIRD_RELEASE_VERSION", runtime.env)
+
+    def test_regular_build_can_enable_pod_install_via_environment(self) -> None:
+        repo_manager = StubRepositoryWorkspaceManager()
+        assembler = BuildEnvironmentAssembler(repo_manager)
+        request = BuildRequestData(
+            flavor="stage",
+            platform="ios",
+            trigger_source="manual",
+            branch_name="stage",
+        )
+        job = BuildJob.create("build-3", request, request.branch_name or "stage", "queue-3")
+
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(
+            os.environ,
+            {
+                "STAGE_FASTLANE_LANE": "deploy_stage",
+                "REPO_URL": "git@github.com:org/app.git",
+                "IOS_RUN_POD_INSTALL": "true",
+            },
+            clear=False,
+        ), patch(
+            "src.internal.application.build_environment.get_isolated_env",
+            return_value={
+                "env": {},
+                "repo_dir": str(Path(tmp) / "repo"),
+                "deriveddata_cache_dir": str(Path(tmp) / "DerivedData"),
+            },
+        ), patch(
+            "src.internal.application.build_environment.get_build_workspace",
+            return_value=Path(tmp) / "workspace",
+        ):
+            runtime = assembler.assemble(
+                job,
+                ResolvedVersions(
+                    flutter_sdk_version="3.24.0",
+                    gradle_version=None,
+                    cocoapods_version=None,
+                    fastlane_version=None,
+                ),
+                lambda _: None,
+            )
+
+        self.assertEqual("true", runtime.env["IOS_RUN_POD_INSTALL"])
+        self.assertEqual("false", runtime.env["IOS_FLUTTER_SDK_CHANGED"])
+
+    def test_regular_build_marks_flutter_sdk_change_in_environment(self) -> None:
+        repo_manager = StubRepositoryWorkspaceManager()
+        repo_manager.flutter_version_changed = True
+        assembler = BuildEnvironmentAssembler(repo_manager)
+        request = BuildRequestData(
+            flavor="stage",
+            platform="ios",
+            trigger_source="manual",
+            branch_name="stage",
+        )
+        job = BuildJob.create("build-4", request, request.branch_name or "stage", "queue-4")
+
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(
+            os.environ,
+            {"STAGE_FASTLANE_LANE": "deploy_stage", "REPO_URL": "git@github.com:org/app.git"},
+            clear=False,
+        ), patch(
+            "src.internal.application.build_environment.get_isolated_env",
+            return_value={
+                "env": {},
+                "repo_dir": str(Path(tmp) / "repo"),
+                "deriveddata_cache_dir": str(Path(tmp) / "DerivedData"),
+            },
+        ), patch(
+            "src.internal.application.build_environment.get_build_workspace",
+            return_value=Path(tmp) / "workspace",
+        ):
+            runtime = assembler.assemble(
+                job,
+                ResolvedVersions(
+                    flutter_sdk_version="3.24.0",
+                    gradle_version=None,
+                    cocoapods_version=None,
+                    fastlane_version=None,
+                ),
+                lambda _: None,
+            )
+
+        self.assertEqual("true", runtime.env["IOS_FLUTTER_SDK_CHANGED"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약
- iOS 빌드에서 `pod install`을 무조건 실행하지 않고 워크스페이스 상태를 기준으로 자동 판정하도록 변경했습니다.
- Flutter SDK 변경 여부를 빌드 환경에 전달해 pod 재설치 판단 조건에 포함했습니다.
- CocoaPods spec 해석 오류로 보일 때만 `--repo-update`를 재시도하도록 조정했습니다.

## 테스트/검증
- `./venv/bin/python -m unittest tests.test_build_environment tests.test_repository_workspace`
- `make doctor`

## 주의사항
- 현재 자동 판정 기준은 `Podfile.lock`, `Pods/Manifest.lock`, `Runner.xcworkspace`, `Flutter/Generated.xcconfig`, `.flutter-plugins-dependencies`, Flutter SDK 변경 여부를 사용합니다.
- 운영에서 강제 override가 필요하면 `IOS_RUN_POD_INSTALL=true|false`로 제어할 수 있습니다.
- 작업 트리에 있던 문서 변경은 이번 PR에 포함하지 않았습니다.