### PR TITLE
fix: dotenv 전체 환경변수 미러링 추가

### DIFF
--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -8,10 +8,12 @@ from pathlib import Path
 from typing import Optional
 
 from pydantic import Field
+from dotenv import dotenv_values
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DOTENV_FILES = (PROJECT_ROOT / ".env", PROJECT_ROOT / "src" / ".env")
 
 
 class AppSettings(BaseSettings):
@@ -39,7 +41,7 @@ class AppSettings(BaseSettings):
     )
 
     model_config = SettingsConfigDict(
-        env_file=(PROJECT_ROOT / ".env", PROJECT_ROOT / "src" / ".env"),
+        env_file=DOTENV_FILES,
         env_file_encoding="utf-8",
         extra="ignore",
     )
@@ -50,9 +52,22 @@ def get_settings() -> AppSettings:
     return AppSettings()
 
 
+def _load_raw_dotenv_into_environ() -> None:
+    """Expose all dotenv entries to os.environ for legacy code paths."""
+
+    for env_file in DOTENV_FILES:
+        if not env_file.exists():
+            continue
+        for key, value in dotenv_values(env_file).items():
+            if key is None or value is None:
+                continue
+            os.environ.setdefault(key, value)
+
+
 def bootstrap_environment(settings: AppSettings | None = None) -> AppSettings:
     """Load settings once and mirror them into os.environ for legacy internals."""
 
+    _load_raw_dotenv_into_environ()
     resolved = settings or get_settings()
     for field_name, field_info in resolved.__class__.model_fields.items():
         env_name = field_info.alias or field_name.upper()
@@ -61,4 +76,3 @@ def bootstrap_environment(settings: AppSettings | None = None) -> AppSettings:
             continue
         os.environ.setdefault(env_name, str(value))
     return resolved
-


### PR DESCRIPTION
## 변경 요약
- `bootstrap_environment()` 시작 시 `.env`, `src/.env` 의 모든 key-value 를 `os.environ` 으로 미러링하도록 추가했습니다.
- 기존 `AppSettings` 기반 typed settings 미러링은 그대로 유지하고, 이미 export 된 쉘 환경변수가 우선되도록 `setdefault` 를 유지했습니다.
- `ConfigDiagnostics` 나 legacy build code 처럼 `os.environ` 을 직접 읽는 경로에서도 `.env` 기반 키를 일관되게 사용할 수 있게 했습니다.

## 테스트/검증 결과
- `./venv/bin/python` 으로 `bootstrap_environment()` 호출 후 `DEV_BRANCH_NAME`, `MATCH_PASSWORD`, `REPO_URL` 이 `os.environ` 에 반영되는 것을 확인했습니다.
- `PYTHONPYCACHEPREFIX=/tmp/local-flutter-cicd-server-pyc make doctor`

## 주의사항
- 현재 로컬 `.env` 실파일에는 `SHOREBIRD_DEV_FASTLANE_LANE` 가 없어서, helper 추가 이후에도 해당 키는 자동 반영되지 않습니다.
- 워크트리에 있던 `docs/*.md` 변경은 이번 PR에 포함하지 않았습니다.