### PR TITLE
fix: iOS 서명 사전 준비 책임 분리

### DIFF
--- a/action/1_ios.sh
+++ b/action/1_ios.sh
@@ -3,7 +3,6 @@
 
 set -euo pipefail
 
-# ✅ 격리된 환경변수 확인
 LOCAL_DIR="${LOCAL_DIR:?LOCAL_DIR 환경변수가 필요합니다}"
 PUB_CACHE="${PUB_CACHE:?PUB_CACHE 환경변수가 필요합니다}"
 GEM_HOME="${GEM_HOME:?GEM_HOME 환경변수가 필요합니다}"
@@ -17,181 +16,42 @@ echo "💎 GEM_HOME: $GEM_HOME"
 echo "🍫 CP_HOME_DIR: $CP_HOME_DIR"
 echo "🏗️ DERIVED_DATA_PATH: $DERIVED_DATA_PATH"
 
-# iOS 디렉토리로 이동
 cd "$LOCAL_DIR/ios" || exit 1
 echo "✅ 현재 디렉토리: $(pwd)"
 
-# 독립적인 환경 확인
-echo ""
-echo "🔍 환경 독립성 검증..."
-echo "  📍 GEM_HOME: $GEM_HOME"
-echo "  📍 GEM_PATH: $GEM_HOME"
-echo "  📍 CP_HOME_DIR: $CP_HOME_DIR"
-echo "  📍 DERIVED_DATA_PATH: $DERIVED_DATA_PATH"
-
-# CocoaPods가 독립 캐시를 사용하는지 확인
 export CP_HOME_DIR="$CP_HOME_DIR"
-
-# DerivedData 경로 설정
 export DERIVED_DATA_PATH="$DERIVED_DATA_PATH"
-
-# Flutter 빌드 시 DerivedData 경로를 사용하도록 환경변수 설정
 export FLUTTER_BUILD_DERIVED_DATA_PATH="$DERIVED_DATA_PATH"
-
-# PATH에 GEM_HOME/bin 추가 (독립 gem 사용)
 export PATH="$GEM_HOME/bin:$PATH"
 export GEM_PATH="$GEM_HOME"
 export BUNDLE_PATH="${BUNDLE_PATH:-$GEM_HOME/bundle}"
 export BUNDLE_DISABLE_SHARED_GEMS="${BUNDLE_DISABLE_SHARED_GEMS:-true}"
 
-USE_BUNDLER=false
-if [ -f "Gemfile" ]; then
-    USE_BUNDLER=true
-fi
-
-echo "  ✅ 독립 환경 설정 완료"
-echo "  📍 BUNDLE_PATH: $BUNDLE_PATH"
-echo ""
-
-# Fastlane 레인 결정
+IOS_USE_BUNDLER="${IOS_USE_BUNDLER:-false}"
+IOS_SHOULD_RUN_POD_INSTALL="${IOS_SHOULD_RUN_POD_INSTALL:-${IOS_RUN_POD_INSTALL:-false}}"
 FASTLANE_LANE="${FASTLANE_LANE:-beta}"
 BUILD_NAME="${BUILD_NAME:-}"
 BUILD_NUMBER="${BUILD_NUMBER:-}"
 COCOAPODS_VERSION="${COCOAPODS_VERSION:-}"
 PATCH_MODE=false
+
 if [[ "$FASTLANE_LANE" == patch_* ]]; then
     PATCH_MODE=true
 fi
-IOS_USE_BUNDLER="${IOS_USE_BUNDLER:-}"
-if [ -z "$IOS_USE_BUNDLER" ]; then
-    if [ "$PATCH_MODE" = true ]; then
-        IOS_USE_BUNDLER=false
-    elif [ "$USE_BUNDLER" = true ]; then
-        IOS_USE_BUNDLER=true
-    else
-        IOS_USE_BUNDLER=false
-    fi
-fi
-IOS_RUN_POD_INSTALL="${IOS_RUN_POD_INSTALL:-auto}"
-SHOULD_RUN_POD_INSTALL=false
-POD_INSTALL_REASONS=()
 
-mark_pod_install_required() {
-    SHOULD_RUN_POD_INSTALL=true
-    POD_INSTALL_REASONS+=("$1")
-}
+echo ""
+echo "🔍 Python 준비 입력 소비..."
+echo "  📍 IOS_USE_BUNDLER: $IOS_USE_BUNDLER"
+echo "  📍 IOS_SHOULD_RUN_POD_INSTALL: $IOS_SHOULD_RUN_POD_INSTALL"
+echo "  📍 BUNDLE_PATH: $BUNDLE_PATH"
+echo ""
 
-ensure_flutter_ios_artifacts() {
-    local project_root
-    local artifact_path
-
-    project_root="$(cd .. && pwd)"
-    artifact_path="$project_root/.fvm/flutter_sdk/bin/cache/artifacts/engine/ios/Flutter.xcframework"
-
-    if [ -d "$artifact_path" ]; then
-        return
-    fi
-
-    echo "⚠️ Missing Flutter iOS engine artifact: $artifact_path"
-    echo "📦 Running fvm flutter precache --ios before pod install"
-    (
-        cd "$project_root"
-        fvm flutter precache --ios
-    )
-    mark_pod_install_required "Flutter iOS engine artifact was repaired via precache"
-}
-
-resolve_pod_state_file() {
-    if [ -f "Pods/Manifest.lock" ]; then
-        echo "Pods/Manifest.lock"
-    elif [ -f "Podfile.lock" ]; then
-        echo "Podfile.lock"
-    else
-        echo ""
-    fi
-}
-
-evaluate_auto_pod_install() {
-    local pod_state_file
-    pod_state_file="$(resolve_pod_state_file)"
-
-    if [ ! -f "Podfile.lock" ]; then
-        mark_pod_install_required "Podfile.lock missing"
-    fi
-    if [ ! -d "Pods/Pods.xcodeproj" ]; then
-        mark_pod_install_required "Pods/Pods.xcodeproj missing"
-    fi
-    if [ ! -d "Runner.xcworkspace" ]; then
-        mark_pod_install_required "Runner.xcworkspace missing"
-    fi
-    if [ ! -f "Flutter/Generated.xcconfig" ]; then
-        mark_pod_install_required "Flutter/Generated.xcconfig missing"
-    fi
-    if [ -f "Podfile.lock" ] && [ -f "Pods/Manifest.lock" ] && ! cmp -s "Podfile.lock" "Pods/Manifest.lock"; then
-        mark_pod_install_required "Podfile.lock and Pods/Manifest.lock differ"
-    fi
-    if [ -n "$pod_state_file" ] && [ -f "Podfile" ] && [ "Podfile" -nt "$pod_state_file" ]; then
-        mark_pod_install_required "Podfile is newer than $pod_state_file"
-    fi
-    if [ -f "../.flutter-plugins-dependencies" ] && { [ -z "$pod_state_file" ] || [ "../.flutter-plugins-dependencies" -nt "$pod_state_file" ]; }; then
-        if [ -n "$pod_state_file" ]; then
-            mark_pod_install_required ".flutter-plugins-dependencies is newer than $pod_state_file"
-        else
-            mark_pod_install_required ".flutter-plugins-dependencies changed without an existing pod state file"
-        fi
-    fi
-    if [ "${IOS_FLUTTER_SDK_CHANGED:-false}" = "true" ]; then
-        mark_pod_install_required "Flutter SDK version changed since previous sync"
-    fi
-}
-
-case "$IOS_RUN_POD_INSTALL" in
-    true|TRUE|1|yes|YES)
-        mark_pod_install_required "forced by IOS_RUN_POD_INSTALL=$IOS_RUN_POD_INSTALL"
-        ;;
-    false|FALSE|0|no|NO)
-        ;;
-    auto|AUTO|"")
-        evaluate_auto_pod_install
-        ;;
-    *)
-        echo "⚠️ Unknown IOS_RUN_POD_INSTALL=$IOS_RUN_POD_INSTALL, falling back to auto detection"
-        evaluate_auto_pod_install
-        ;;
-esac
-
-# # Flutter 아티팩트 준비
-# echo "📦 Ensuring flutter artifacts..."
-# pushd .. > /dev/null
-# # iOS 네이티브 프로젝트 설정 파일 생성 (필수)
-# fvm flutter --suppress-analytics --no-version-check build ios --config-only || true
-# popd > /dev/null
-
-if [ "$USE_BUNDLER" = true ]; then
-    echo "📦 Gemfile detected, using Bundler prepared by Python setup"
-    if [ -f "Gemfile.lock" ]; then
-        LOCKED_COCOAPODS_VERSION="$(ruby -e 'lock = File.read("Gemfile.lock"); match = lock.match(/^ {4}cocoapods \(([^)]+)\)$/); puts(match ? match[1] : "")')"
-        if [ -n "$LOCKED_COCOAPODS_VERSION" ]; then
-            echo "📦 Gemfile.lock CocoaPods version: $LOCKED_COCOAPODS_VERSION"
-        else
-            echo "⚠️ Gemfile.lock exists but CocoaPods version could not be parsed"
-        fi
-    else
-        echo "⚠️ Gemfile detected without Gemfile.lock"
-    fi
+if [ "$IOS_USE_BUNDLER" = true ]; then
+    echo "📦 Using Bundler prepared by Python setup"
 else
     echo "📦 Using gem-based tooling prepared by Python setup"
-    if ! gem list -i cocoapods > /dev/null 2>&1; then
-        echo "❌ CocoaPods is not installed. Python setup should prepare it before this script runs."
-        exit 1
-    fi
-    if ! gem list -i fastlane > /dev/null 2>&1; then
-        echo "❌ Fastlane is not installed. Python setup should prepare it before this script runs."
-        exit 1
-    fi
 fi
 
-# CocoaPods 버전 확인
 echo "📦 CocoaPods version:"
 if [ -n "$COCOAPODS_VERSION" ]; then
     echo "📦 Executing CocoaPods via: pod _${COCOAPODS_VERSION}_"
@@ -204,13 +64,11 @@ else
     pod --version
 fi
 
-ensure_flutter_ios_artifacts
-
-# pod install 실행
-if [ "$SHOULD_RUN_POD_INSTALL" = true ]; then
+if [ "$IOS_SHOULD_RUN_POD_INSTALL" = true ]; then
     echo "📚 Running pod install..."
-    printf '  • %s\n' "${POD_INSTALL_REASONS[@]}"
-
+    if [ -n "${IOS_POD_INSTALL_REASONS:-}" ]; then
+        echo "  • $IOS_POD_INSTALL_REASONS"
+    fi
     if [ -n "$COCOAPODS_VERSION" ]; then
         POD_INSTALL_CMD=(pod "_${COCOAPODS_VERSION}_" install)
     elif [ "$IOS_USE_BUNDLER" = true ]; then
@@ -219,38 +77,11 @@ if [ "$SHOULD_RUN_POD_INSTALL" = true ]; then
         POD_INSTALL_CMD=(pod install)
     fi
 
-    POD_INSTALL_LOG="$(mktemp)"
-    if "${POD_INSTALL_CMD[@]}" >"$POD_INSTALL_LOG" 2>&1; then
-        cat "$POD_INSTALL_LOG"
-    else
-        cat "$POD_INSTALL_LOG"
-        if grep -Eiq "Unable to find a specification|could not find compatible versions|out-of-date source repos|Specs satisfying the" "$POD_INSTALL_LOG"; then
-            echo "⚠️ pod install failed with a spec resolution error, retrying with --repo-update"
-            "${POD_INSTALL_CMD[@]}" --repo-update
-        else
-            echo "❌ pod install failed without a repo update hint"
-            rm -f "$POD_INSTALL_LOG"
-            exit 1
-        fi
-    fi
-    rm -f "$POD_INSTALL_LOG"
+    "${POD_INSTALL_CMD[@]}"
 else
-    echo "⏭️ Skipping pod install (IOS_RUN_POD_INSTALL=$IOS_RUN_POD_INSTALL, auto-detect found no changes)"
+    echo "⏭️ Skipping pod install (IOS_SHOULD_RUN_POD_INSTALL=$IOS_SHOULD_RUN_POD_INSTALL)"
 fi
 
-# # Fastlane match (필요시)
-# # Flavor에 따라 match 타입 결정
-# MATCH_TYPE="appstore"
-# if [ "$FLAVOR" = "dev" ]; then
-#     MATCH_TYPE="development"
-# fi
-
-# echo "🔑 Running fastlane match ($MATCH_TYPE)..."
-# if ! fvm exec fastlane match $MATCH_TYPE --readonly; then
-#     echo "⚠️ Fastlane match failed, but continuing (might be optional)"
-# fi
-
-# Fastlane 명령 구성
 if [ "$IOS_USE_BUNDLER" = true ]; then
     FASTLANE_CMD=(bundle exec fastlane "$FASTLANE_LANE")
 else
@@ -287,14 +118,12 @@ else
     fi
 fi
 
-# Fastlane 실행 전 DerivedData 관련 환경변수 설정
 export GYM_DERIVED_DATA_PATH="$DERIVED_DATA_PATH"
 export GYM_XCARCHIVE_PATH="$DERIVED_DATA_PATH/Archives"
 
-# Fastlane 실행
 echo "🚀 Running: ${FASTLANE_CMD[*]}"
 echo "📦 Using Bundler for Ruby tools: $IOS_USE_BUNDLER"
-echo "📚 Run pod install: $SHOULD_RUN_POD_INSTALL"
+echo "📚 Run pod install: $IOS_SHOULD_RUN_POD_INSTALL"
 echo "🏗️ Using DerivedData path: $DERIVED_DATA_PATH"
 echo "🏗️ GYM_DERIVED_DATA_PATH: $GYM_DERIVED_DATA_PATH"
 echo "🏗️ GYM_XCARCHIVE_PATH: $GYM_XCARCHIVE_PATH"

--- a/src/internal/application/build_environment.py
+++ b/src/internal/application/build_environment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 from ..core import BuildRuntimeContext
 from ..core.config import get_build_workspace, get_isolated_env
@@ -35,7 +36,6 @@ class BuildEnvironmentAssembler:
                 "FLAVOR": job.flavor,
                 "TRIGGER_SOURCE": job.trigger_source,
                 "FASTLANE_LANE": fastlane_lane,
-                "IOS_USE_BUNDLER": self._resolve_ios_use_bundler(job),
                 "IOS_RUN_POD_INSTALL": self._resolve_ios_run_pod_install(),
                 "DATADOG_API_KEY": os.environ.get("DATADOG_API_KEY", ""),
                 "GYM_DERIVED_DATA_PATH": isolated["deriveddata_cache_dir"],
@@ -56,6 +56,7 @@ class BuildEnvironmentAssembler:
             should_cancel=should_cancel,
         )
         env["LOCAL_DIR"] = prepared.repo_dir
+        env["IOS_USE_BUNDLER"] = self._resolve_ios_use_bundler(job, Path(prepared.repo_dir) / "ios")
         # Force pod install auto-detection when iOS precache had to repair SDK state.
         env["IOS_FLUTTER_SDK_CHANGED"] = "true" if (prepared.flutter_version_changed or prepared.precache_ran) else "false"
         job.mark_stage_completed("repository_synced", f"Repository synchronized for {job.branch_name}")
@@ -133,7 +134,9 @@ class BuildEnvironmentAssembler:
             return os.environ.get(f"SHOREBIRD_{job.flavor.upper()}_FASTLANE_LANE", f"patch_{job.flavor}")
         return os.environ.get(f"{job.flavor.upper()}_FASTLANE_LANE", "beta")
 
-    def _resolve_ios_use_bundler(self, job: BuildJob) -> str:
+    def _resolve_ios_use_bundler(self, job: BuildJob, ios_dir: Path) -> str:
+        if not ios_dir.exists() or not (ios_dir / "Gemfile").exists():
+            return "false"
         if job.platform in {"ios", "all"} and job.trigger_source in {"shorebird", "shorebird_manual"}:
             return "false"
         return "true"

--- a/src/internal/infrastructure/platform_toolchain.py
+++ b/src/internal/infrastructure/platform_toolchain.py
@@ -93,15 +93,28 @@ class IOSKeychainPreparer:
         keychain_name = (context.env.get("KEYCHAIN_NAME") or "").strip()
         keychain_password = context.env.get("KEYCHAIN_PASSWORD")
         if not keychain_name:
-            log(f"[{build_id}] ℹ️ KEYCHAIN_NAME not set; skipping keychain preparation")
-            return
+            raise RuntimeError("KEYCHAIN_NAME is required for iOS signing environment preparation")
 
-        keychain_path = self._resolve_keychain_path(keychain_name)
-        if not keychain_path:
-            raise RuntimeError(f"Configured keychain '{keychain_name}' could not be found")
+        keychain_path = self._resolve_keychain_path(keychain_name) or self._planned_keychain_path(keychain_name)
+        if keychain_path is None:
+            raise RuntimeError(f"Configured keychain '{keychain_name}' could not be resolved")
+
+        is_login_keychain = self._is_login_keychain(keychain_path)
+        if not keychain_path.exists():
+            if is_login_keychain:
+                raise RuntimeError(f"Configured login keychain '{keychain_name}' could not be found")
+            if not keychain_password:
+                raise RuntimeError("KEYCHAIN_PASSWORD is required when creating a custom keychain")
+            keychain_path.parent.mkdir(parents=True, exist_ok=True)
+            self.command_runner.run_checked(
+                ["security", "create-keychain", "-p", keychain_password, str(keychain_path)],
+                env=context.env,
+                cwd=str(cwd),
+                should_stop=should_cancel,
+            )
+            log(f"[{build_id}] 🔐 Created keychain: {keychain_path.name}")
 
         keychain_str = str(keychain_path)
-        is_login_keychain = self._is_login_keychain(keychain_path)
         existing = self.command_runner.run(
             ["security", "list-keychains", "-d", "user"],
             env=context.env,
@@ -137,7 +150,7 @@ class IOSKeychainPreparer:
                     "continuing with existing user session state"
                 )
         elif is_login_keychain:
-                log(f"[{build_id}] ℹ️ KEYCHAIN_PASSWORD not set for login keychain; using existing user session state")
+            log(f"[{build_id}] ℹ️ KEYCHAIN_PASSWORD not set for login keychain; using existing user session state")
         else:
             raise RuntimeError("KEYCHAIN_PASSWORD is required when KEYCHAIN_NAME points to a custom keychain")
 
@@ -158,6 +171,7 @@ class IOSKeychainPreparer:
             cwd=str(cwd),
             should_stop=should_cancel,
         )
+        context.env["KEYCHAIN_PATH"] = keychain_str
         context.env["MATCH_KEYCHAIN_NAME"] = keychain_str
         if unlocked_with_password or not is_login_keychain:
             context.env["MATCH_KEYCHAIN_PASSWORD"] = keychain_password or ""
@@ -169,6 +183,16 @@ class IOSKeychainPreparer:
         provided = Path(keychain_name).expanduser()
         if provided.exists():
             return provided.resolve()
+
+        planned = self._planned_keychain_path(keychain_name)
+        if planned and planned.exists():
+            return planned.resolve()
+        return None
+
+    def _planned_keychain_path(self, keychain_name: str) -> Path | None:
+        provided = Path(keychain_name).expanduser()
+        if provided.is_absolute():
+            return provided
 
         keychain_dir = Path.home() / "Library" / "Keychains"
         candidates = [keychain_name]
@@ -185,7 +209,11 @@ class IOSKeychainPreparer:
             path = (keychain_dir / candidate).expanduser()
             if path.exists():
                 return path.resolve()
-        return None
+        if keychain_name.endswith(".keychain-db"):
+            return (keychain_dir / keychain_name).expanduser()
+        if keychain_name.endswith(".keychain"):
+            return (keychain_dir / f"{keychain_name}-db").expanduser()
+        return (keychain_dir / f"{keychain_name}.keychain-db").expanduser()
 
     def _parse_keychains(self, output: str) -> list[str]:
         parsed: list[str] = []
@@ -198,6 +226,7 @@ class IOSKeychainPreparer:
     def _is_login_keychain(self, keychain_path: Path) -> bool:
         name = keychain_path.name
         return name in {"login.keychain", "login.keychain-db"}
+
 
 class PlatformToolchainPreparer:
     """Prepare per-platform Ruby and native build toolchains."""
@@ -258,7 +287,10 @@ class PlatformToolchainPreparer:
         if not ios_dir.exists():
             return
 
+        self._validate_ios_runtime_requirements(build_id, context, log)
         self.ios_keychain.prepare(build_id, context, ios_dir, log, should_cancel=should_cancel)
+        self._prepare_flutter_ios_artifacts(build_id, context, ios_dir, log, should_cancel=should_cancel)
+        self._plan_ios_pod_install(build_id, context, ios_dir, log)
         self.ruby_toolchain.configure_environment(ios_dir, context.env, build_id, log, should_cancel=should_cancel)
         if (ios_dir / "Gemfile").exists():
             self.ruby_toolchain.ensure_gem(
@@ -289,6 +321,120 @@ class PlatformToolchainPreparer:
             "fastlane", context.env.get("FASTLANE_VERSION"), ios_dir, context.env, build_id, log, should_cancel=should_cancel
         )
         self.ruby_toolchain.install_fastlane_plugins(ios_dir, context.env, build_id, log, should_cancel=should_cancel)
+
+    def _validate_ios_runtime_requirements(self, build_id: str, context: BuildRuntimeContext, log) -> None:
+        keychain_name = (context.env.get("KEYCHAIN_NAME") or "").strip()
+        if not keychain_name:
+            raise RuntimeError("KEYCHAIN_NAME is required for iOS builds")
+
+        keychain_password = context.env.get("KEYCHAIN_PASSWORD", "").strip()
+        keychain_path = (
+            self.ios_keychain._resolve_keychain_path(keychain_name)
+            or self.ios_keychain._planned_keychain_path(keychain_name)
+        )
+        is_login_keychain = bool(keychain_path and self.ios_keychain._is_login_keychain(keychain_path))
+        if not is_login_keychain and not keychain_password:
+            raise RuntimeError("KEYCHAIN_PASSWORD is required when KEYCHAIN_NAME points to a custom keychain")
+
+        match_password = (context.env.get("MATCH_PASSWORD") or "").strip()
+        if not match_password:
+            raise RuntimeError("MATCH_PASSWORD is required for iOS builds")
+
+        has_appstore_api = all(
+            (context.env.get(key) or "").strip()
+            for key in ("APPSTORE_API_KEY_ID", "APPSTORE_ISSUER_ID", "APPSTORE_API_PRIVATE_KEY")
+        )
+        has_fastlane_session = all(
+            (context.env.get(key) or "").strip()
+            for key in ("FASTLANE_USER", "FASTLANE_PASSWORD")
+        )
+        if not has_appstore_api and not has_fastlane_session:
+            raise RuntimeError(
+                "App Store authentication is required for iOS builds. "
+                "Set APPSTORE_API_KEY_ID/APPSTORE_ISSUER_ID/APPSTORE_API_PRIVATE_KEY or FASTLANE_USER/FASTLANE_PASSWORD."
+            )
+
+        log(f"[{build_id}] ✅ iOS signing prerequisites are present before Fastlane")
+
+    def _prepare_flutter_ios_artifacts(
+        self,
+        build_id: str,
+        context: BuildRuntimeContext,
+        ios_dir: Path,
+        log,
+        should_cancel=None,
+    ) -> None:
+        project_root = ios_dir.parent
+        artifact_path = project_root / ".fvm" / "flutter_sdk" / "bin" / "cache" / "artifacts" / "engine" / "ios" / "Flutter.xcframework"
+        if artifact_path.exists():
+            return
+
+        log(f"[{build_id}] 📦 Flutter iOS engine artifact missing; running fvm flutter precache --ios")
+        self.command_runner.run_checked(
+            ["fvm", "flutter", "precache", "--ios"],
+            env=context.env,
+            cwd=str(project_root),
+            should_stop=should_cancel,
+        )
+        context.env["IOS_FLUTTER_SDK_CHANGED"] = "true"
+
+    def _plan_ios_pod_install(self, build_id: str, context: BuildRuntimeContext, ios_dir: Path, log) -> None:
+        requested_policy = (context.env.get("IOS_RUN_POD_INSTALL") or "auto").strip()
+        normalized_policy = requested_policy.lower()
+        reasons: list[str] = []
+        should_run = False
+
+        if normalized_policy in {"true", "1", "yes"}:
+            should_run = True
+            reasons.append(f"forced by IOS_RUN_POD_INSTALL={requested_policy}")
+        elif normalized_policy in {"false", "0", "no"}:
+            should_run = False
+        else:
+            if normalized_policy not in {"auto", ""}:
+                log(f"[{build_id}] ⚠️ Unknown IOS_RUN_POD_INSTALL={requested_policy}; falling back to auto detection")
+            should_run, reasons = self._detect_ios_pod_install_reasons(context, ios_dir)
+
+        context.env["IOS_SHOULD_RUN_POD_INSTALL"] = "true" if should_run else "false"
+        context.env["IOS_POD_INSTALL_REASONS"] = " | ".join(reasons)
+        if should_run:
+            log(f"[{build_id}] 📚 pod install scheduled: {' | '.join(reasons)}")
+        else:
+            log(f"[{build_id}] ⏭️ pod install not required before Fastlane")
+
+    def _detect_ios_pod_install_reasons(self, context: BuildRuntimeContext, ios_dir: Path) -> tuple[bool, list[str]]:
+        reasons: list[str] = []
+        podfile_lock = ios_dir / "Podfile.lock"
+        pods_manifest = ios_dir / "Pods" / "Manifest.lock"
+        pod_state_file = pods_manifest if pods_manifest.exists() else podfile_lock if podfile_lock.exists() else None
+
+        if not podfile_lock.exists():
+            reasons.append("Podfile.lock missing")
+        if not (ios_dir / "Pods" / "Pods.xcodeproj").exists():
+            reasons.append("Pods/Pods.xcodeproj missing")
+        if not (ios_dir / "Runner.xcworkspace").exists():
+            reasons.append("Runner.xcworkspace missing")
+        if not (ios_dir / "Flutter" / "Generated.xcconfig").exists():
+            reasons.append("Flutter/Generated.xcconfig missing")
+        if podfile_lock.exists() and pods_manifest.exists() and podfile_lock.read_bytes() != pods_manifest.read_bytes():
+            reasons.append("Podfile.lock and Pods/Manifest.lock differ")
+        if (
+            pod_state_file
+            and (ios_dir / "Podfile").exists()
+            and (ios_dir / "Podfile").stat().st_mtime > pod_state_file.stat().st_mtime
+        ):
+            reasons.append(f"Podfile is newer than {pod_state_file.relative_to(ios_dir)}")
+
+        plugins_dependencies = ios_dir.parent / ".flutter-plugins-dependencies"
+        if plugins_dependencies.exists():
+            if pod_state_file is None:
+                reasons.append(".flutter-plugins-dependencies changed without an existing pod state file")
+            elif plugins_dependencies.stat().st_mtime > pod_state_file.stat().st_mtime:
+                reasons.append(f".flutter-plugins-dependencies is newer than {pod_state_file.relative_to(ios_dir)}")
+
+        if (context.env.get("IOS_FLUTTER_SDK_CHANGED") or "").strip().lower() == "true":
+            reasons.append("Flutter SDK version changed since previous sync")
+
+        return bool(reasons), reasons
 
     def _prepare_android_toolchain(
         self,

--- a/tests/test_build_environment.py
+++ b/tests/test_build_environment.py
@@ -17,11 +17,16 @@ class StubRepositoryWorkspaceManager:
         self.calls = []
         self.flutter_version_changed = False
         self.precache_ran = False
+        self.create_ios_gemfile = True
 
     def prepare(self, **kwargs):
         self.calls.append(kwargs)
         repo_dir = Path(kwargs["repo_dir"])
         repo_dir.mkdir(parents=True, exist_ok=True)
+        ios_dir = repo_dir / "ios"
+        ios_dir.mkdir(parents=True, exist_ok=True)
+        if self.create_ios_gemfile:
+            (ios_dir / "Gemfile").write_text("source 'https://rubygems.org'\n", encoding="utf-8")
         return PreparedRepositoryResult(
             flutter_version="3.24.0",
             precache_ran=self.precache_ran,
@@ -258,6 +263,46 @@ class BuildEnvironmentAssemblerTests(unittest.TestCase):
             )
 
         self.assertEqual("true", runtime.env["IOS_FLUTTER_SDK_CHANGED"])
+
+    def test_regular_build_disables_bundler_when_ios_gemfile_is_missing(self) -> None:
+        repo_manager = StubRepositoryWorkspaceManager()
+        repo_manager.create_ios_gemfile = False
+        assembler = BuildEnvironmentAssembler(repo_manager)
+        request = BuildRequestData(
+            flavor="stage",
+            platform="ios",
+            trigger_source="manual",
+            branch_name="stage",
+        )
+        job = BuildJob.create("build-no-gemfile", request, request.branch_name or "stage", "queue-no-gemfile")
+
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(
+            os.environ,
+            {"STAGE_FASTLANE_LANE": "deploy_stage", "REPO_URL": "git@github.com:org/app.git"},
+            clear=False,
+        ), patch(
+            "src.internal.application.build_environment.get_isolated_env",
+            return_value={
+                "env": {},
+                "repo_dir": str(Path(tmp) / "repo"),
+                "deriveddata_cache_dir": str(Path(tmp) / "DerivedData"),
+            },
+        ), patch(
+            "src.internal.application.build_environment.get_build_workspace",
+            return_value=Path(tmp) / "workspace",
+        ):
+            runtime = assembler.assemble(
+                job,
+                ResolvedVersions(
+                    flutter_sdk_version="3.24.0",
+                    gradle_version=None,
+                    cocoapods_version=None,
+                    fastlane_version=None,
+                ),
+                lambda _: None,
+            )
+
+        self.assertEqual("false", runtime.env["IOS_USE_BUNDLER"])
 
     def test_regular_build_marks_flutter_sdk_state_changed_when_precache_runs(self) -> None:
         repo_manager = StubRepositoryWorkspaceManager()

--- a/tests/test_setup_executor.py
+++ b/tests/test_setup_executor.py
@@ -35,6 +35,53 @@ class FakeCommandRunner:
         return result
 
 
+def create_flutter_ios_artifact(repo_dir: Path) -> None:
+    artifact_dir = repo_dir / ".fvm" / "flutter_sdk" / "bin" / "cache" / "artifacts" / "engine" / "ios" / "Flutter.xcframework"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+
+def default_ios_env(**overrides: str) -> dict[str, str]:
+    env = {
+        "GEM_HOME": "/tmp/gems",
+        "KEYCHAIN_NAME": "login.keychain",
+        "KEYCHAIN_PASSWORD": "secret",
+        "MATCH_PASSWORD": "match-secret",
+        "APPSTORE_API_KEY_ID": "key-id",
+        "APPSTORE_ISSUER_ID": "issuer-id",
+        "APPSTORE_API_PRIVATE_KEY": "private-key",
+    }
+    env.update(overrides)
+    return env
+
+
+def register_login_keychain(
+    runner: FakeCommandRunner,
+    home: Path,
+    *,
+    password: str = "secret",
+    listed: bool = True,
+) -> Path:
+    keychain_dir = home / "Library" / "Keychains"
+    keychain_dir.mkdir(parents=True, exist_ok=True)
+    keychain_path = keychain_dir / "login.keychain-db"
+    keychain_path.write_text("", encoding="utf-8")
+
+    if listed:
+        runner.add_response(
+            ["security", "list-keychains", "-d", "user"],
+            stdout=f"    \"{keychain_path.resolve()}\"\n",
+        )
+    else:
+        runner.add_response(["security", "list-keychains", "-d", "user"], stdout="    \"/tmp/other.keychain-db\"\n")
+        runner.add_response(
+            ["security", "list-keychains", "-d", "user", "-s", "/tmp/other.keychain-db", str(keychain_path.resolve())]
+        )
+    runner.add_response(["security", "unlock-keychain", "-p", password, str(keychain_path.resolve())])
+    runner.add_response(["security", "set-keychain-settings", "-lut", "21600", str(keychain_path.resolve())])
+    runner.add_response(["security", "default-keychain", "-d", "user", "-s", str(keychain_path.resolve())])
+    return keychain_path
+
+
 class SetupExecutorTests(unittest.TestCase):
     def test_run_setup_repairs_cache_and_retries_pub_get_without_melos(self) -> None:
         runner = FakeCommandRunner()
@@ -115,7 +162,7 @@ class SetupExecutorTests(unittest.TestCase):
         runner.add_response(["bundle", "_2.7.2_", "config", "set", "--local", "path", "/tmp/gems/ruby-3.2.0/bundle"])
         runner.add_response(["bundle", "_2.7.2_", "install"], stdout="bundle ok")
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as home:
             repo_dir = Path(tmp) / "repo"
             ios_dir = repo_dir / "ios"
             ios_dir.mkdir(parents=True)
@@ -131,19 +178,22 @@ class SetupExecutorTests(unittest.TestCase):
                 "   2.7.2\n",
                 encoding="utf-8",
             )
+            create_flutter_ios_artifact(repo_dir)
+            register_login_keychain(runner, Path(home))
 
             context = BuildRuntimeContext(
-                env={"GEM_HOME": "/tmp/gems", "COCOAPODS_VERSION": "1.16.2"},
+                env=default_ios_env(COCOAPODS_VERSION="1.16.2"),
                 repo_dir=str(repo_dir),
                 workspace=tmp,
             )
 
-            executor.prepare_platform_toolchain(
-                build_id="build-ios",
-                platform="ios",
-                context=context,
-                log=logs.append,
-            )
+            with patch("pathlib.Path.home", return_value=Path(home)):
+                executor.prepare_platform_toolchain(
+                    build_id="build-ios",
+                    platform="ios",
+                    context=context,
+                    log=logs.append,
+                )
 
         self.assertIn(("gem", "list", "-i", "cocoapods", "-v", "1.16.2"), runner.calls)
         self.assertIn(("gem", "list", "-i", "bundler", "-v", "2.7.2"), runner.calls)
@@ -152,6 +202,7 @@ class SetupExecutorTests(unittest.TestCase):
         self.assertTrue(any("Installing Ruby bundle" in line for line in logs))
         self.assertEqual("/tmp/gems/ruby-3.2.0", context.env["GEM_HOME"])
         self.assertEqual("/tmp/gems/ruby-3.2.0/bundle", context.env["BUNDLE_PATH"])
+        self.assertEqual("true", context.env["IOS_SHOULD_RUN_POD_INSTALL"])
 
     def test_prepare_ios_toolchain_prepares_standalone_fastlane_for_shorebird_patch(self) -> None:
         runner = FakeCommandRunner()
@@ -166,7 +217,7 @@ class SetupExecutorTests(unittest.TestCase):
         runner.add_response(["gem", "list", "-i", "fastlane"], returncode=0)
         runner.add_response(["gem", "list", "-i", "fastlane-plugin-shorebird"], returncode=0)
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as home:
             repo_dir = Path(tmp) / "repo"
             ios_dir = repo_dir / "ios"
             fastlane_dir = ios_dir / "fastlane"
@@ -187,20 +238,23 @@ class SetupExecutorTests(unittest.TestCase):
                 "gem 'fastlane-plugin-shorebird'\n",
                 encoding="utf-8",
             )
+            create_flutter_ios_artifact(repo_dir)
+            register_login_keychain(runner, Path(home))
 
             context = BuildRuntimeContext(
-                env={"GEM_HOME": "/tmp/gems", "COCOAPODS_VERSION": "1.16.2"},
+                env=default_ios_env(COCOAPODS_VERSION="1.16.2"),
                 repo_dir=str(repo_dir),
                 workspace=tmp,
                 trigger_source="shorebird_manual",
             )
 
-            executor.prepare_platform_toolchain(
-                build_id="build-ios-shorebird",
-                platform="ios",
-                context=context,
-                log=lambda _: None,
-            )
+            with patch("pathlib.Path.home", return_value=Path(home)):
+                executor.prepare_platform_toolchain(
+                    build_id="build-ios-shorebird",
+                    platform="ios",
+                    context=context,
+                    log=lambda _: None,
+                )
 
         self.assertIn(("bundle", "_2.7.2_", "install"), runner.calls)
         self.assertIn(("gem", "list", "-i", "fastlane"), runner.calls)
@@ -255,18 +309,7 @@ class SetupExecutorTests(unittest.TestCase):
         logs: list[str] = []
 
         with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as home:
-            keychain_dir = Path(home) / "Library" / "Keychains"
-            keychain_dir.mkdir(parents=True, exist_ok=True)
-            keychain_path = keychain_dir / "login.keychain-db"
-            keychain_path.write_text("", encoding="utf-8")
-
-            runner.add_response(["security", "list-keychains", "-d", "user"], stdout="    \"/tmp/other.keychain-db\"\n")
-            runner.add_response(
-                ["security", "list-keychains", "-d", "user", "-s", "/tmp/other.keychain-db", str(keychain_path.resolve())]
-            )
-            runner.add_response(["security", "unlock-keychain", "-p", "secret", str(keychain_path.resolve())])
-            runner.add_response(["security", "set-keychain-settings", "-lut", "21600", str(keychain_path.resolve())])
-            runner.add_response(["security", "default-keychain", "-d", "user", "-s", str(keychain_path.resolve())])
+            keychain_path = register_login_keychain(runner, Path(home), listed=False)
             runner.add_response(["rbenv", "versions", "--bare"], stdout="3.2.0\n")
             runner.add_response(["ruby", "-e", "print RUBY_VERSION"], stdout="3.2.0")
             runner.add_response(["gem", "list", "-i", "cocoapods"], returncode=0)
@@ -275,12 +318,9 @@ class SetupExecutorTests(unittest.TestCase):
             repo_dir = Path(tmp) / "repo"
             ios_dir = repo_dir / "ios"
             ios_dir.mkdir(parents=True)
+            create_flutter_ios_artifact(repo_dir)
             context = BuildRuntimeContext(
-                env={
-                    "GEM_HOME": "/tmp/gems",
-                    "KEYCHAIN_NAME": "login.keychain",
-                    "KEYCHAIN_PASSWORD": "secret",
-                },
+                env=default_ios_env(),
                 repo_dir=str(repo_dir),
                 workspace=tmp,
             )
@@ -295,6 +335,7 @@ class SetupExecutorTests(unittest.TestCase):
 
         self.assertIn(("security", "unlock-keychain", "-p", "secret", str(keychain_path.resolve())), runner.calls)
         self.assertIn(("security", "default-keychain", "-d", "user", "-s", str(keychain_path.resolve())), runner.calls)
+        self.assertEqual(str(keychain_path.resolve()), context.env["KEYCHAIN_PATH"])
         self.assertEqual(str(keychain_path.resolve()), context.env["MATCH_KEYCHAIN_NAME"])
         self.assertEqual("secret", context.env["MATCH_KEYCHAIN_PASSWORD"])
         self.assertTrue(any("Prepared keychain" in line for line in logs))
@@ -309,7 +350,6 @@ class SetupExecutorTests(unittest.TestCase):
             keychain_dir.mkdir(parents=True, exist_ok=True)
             keychain_path = keychain_dir / "login.keychain-db"
             keychain_path.write_text("", encoding="utf-8")
-
             runner.add_response(["security", "list-keychains", "-d", "user"], stdout="    \"/tmp/other.keychain-db\"\n")
             runner.add_response(
                 ["security", "list-keychains", "-d", "user", "-s", "/tmp/other.keychain-db", str(keychain_path.resolve())]
@@ -329,12 +369,9 @@ class SetupExecutorTests(unittest.TestCase):
             repo_dir = Path(tmp) / "repo"
             ios_dir = repo_dir / "ios"
             ios_dir.mkdir(parents=True)
+            create_flutter_ios_artifact(repo_dir)
             context = BuildRuntimeContext(
-                env={
-                    "GEM_HOME": "/tmp/gems",
-                    "KEYCHAIN_NAME": "login.keychain",
-                    "KEYCHAIN_PASSWORD": "wrong-secret",
-                },
+                env=default_ios_env(KEYCHAIN_PASSWORD="wrong-secret"),
                 repo_dir=str(repo_dir),
                 workspace=tmp,
             )
@@ -351,6 +388,81 @@ class SetupExecutorTests(unittest.TestCase):
         self.assertEqual(str(keychain_path.resolve()), context.env["MATCH_KEYCHAIN_NAME"])
         self.assertNotIn("MATCH_KEYCHAIN_PASSWORD", context.env)
         self.assertTrue(any("login keychain unlock failed" in line for line in logs))
+
+    def test_prepare_ios_toolchain_creates_custom_keychain_when_missing(self) -> None:
+        runner = FakeCommandRunner()
+        executor = SetupExecutor(runner)
+        logs: list[str] = []
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as home:
+            repo_dir = Path(tmp) / "repo"
+            ios_dir = repo_dir / "ios"
+            ios_dir.mkdir(parents=True)
+            create_flutter_ios_artifact(repo_dir)
+
+            custom_keychain = Path(home) / "Library" / "Keychains" / "ppb_ci_signing.keychain-db"
+            runner.add_response(["security", "create-keychain", "-p", "secret", str(custom_keychain)])
+            runner.add_response(["security", "list-keychains", "-d", "user"], stdout="")
+            runner.add_response(["security", "list-keychains", "-d", "user", "-s", str(custom_keychain)])
+            runner.add_response(["security", "unlock-keychain", "-p", "secret", str(custom_keychain)])
+            runner.add_response(["security", "set-keychain-settings", "-lut", "21600", str(custom_keychain)])
+            runner.add_response(["security", "default-keychain", "-d", "user", "-s", str(custom_keychain)])
+            runner.add_response(["rbenv", "versions", "--bare"], stdout="3.2.0\n")
+            runner.add_response(["ruby", "-e", "print RUBY_VERSION"], stdout="3.2.0")
+            runner.add_response(["gem", "list", "-i", "cocoapods"], returncode=0)
+            runner.add_response(["gem", "list", "-i", "fastlane"], returncode=0)
+
+            context = BuildRuntimeContext(
+                env=default_ios_env(KEYCHAIN_NAME="ppb_ci_signing", MATCH_PASSWORD="match-secret"),
+                repo_dir=str(repo_dir),
+                workspace=tmp,
+            )
+
+            with patch("pathlib.Path.home", return_value=Path(home)):
+                executor.prepare_platform_toolchain(
+                    build_id="build-custom-keychain",
+                    platform="ios",
+                    context=context,
+                    log=logs.append,
+                )
+
+        self.assertIn(("security", "create-keychain", "-p", "secret", str(custom_keychain)), runner.calls)
+        self.assertEqual(str(custom_keychain), context.env["KEYCHAIN_PATH"])
+        self.assertEqual(str(custom_keychain), context.env["MATCH_KEYCHAIN_NAME"])
+        self.assertEqual("secret", context.env["MATCH_KEYCHAIN_PASSWORD"])
+        self.assertTrue(any("Created keychain" in line for line in logs))
+
+    def test_prepare_ios_toolchain_repairs_missing_flutter_artifact_before_fastlane(self) -> None:
+        runner = FakeCommandRunner()
+        executor = SetupExecutor(runner)
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as home:
+            repo_dir = Path(tmp) / "repo"
+            ios_dir = repo_dir / "ios"
+            ios_dir.mkdir(parents=True)
+            register_login_keychain(runner, Path(home))
+            runner.add_response(["fvm", "flutter", "precache", "--ios"])
+            runner.add_response(["rbenv", "versions", "--bare"], stdout="3.2.0\n")
+            runner.add_response(["ruby", "-e", "print RUBY_VERSION"], stdout="3.2.0")
+            runner.add_response(["gem", "list", "-i", "cocoapods"], returncode=0)
+            runner.add_response(["gem", "list", "-i", "fastlane"], returncode=0)
+
+            context = BuildRuntimeContext(
+                env=default_ios_env(IOS_RUN_POD_INSTALL="false"),
+                repo_dir=str(repo_dir),
+                workspace=tmp,
+            )
+
+            with patch("pathlib.Path.home", return_value=Path(home)):
+                executor.prepare_platform_toolchain(
+                    build_id="build-precache-ios",
+                    platform="ios",
+                    context=context,
+                    log=lambda _: None,
+                )
+
+        self.assertIn(("fvm", "flutter", "precache", "--ios"), runner.calls)
+        self.assertEqual("true", context.env["IOS_FLUTTER_SDK_CHANGED"])
 
     def test_prepare_android_toolchain_fails_when_lockfile_requires_newer_ruby(self) -> None:
         runner = FakeCommandRunner()


### PR DESCRIPTION
## 변경 요약
- Python이 iOS keychain 생성, unlock, default/search list 설정과 signing preflight를 직접 준비하도록 정리했습니다.
- iOS Flutter artifact 복구와 `pod install` 필요 여부 판단을 Python으로 이동하고, shell은 준비된 입력만 소비하도록 단순화했습니다.
- 저장소 상태에 따라 `IOS_USE_BUNDLER`를 조립하도록 env assembly를 보강하고 관련 테스트를 추가했습니다.

## 테스트
- `./venv/bin/python -m unittest tests.test_build_environment tests.test_setup_executor tests.test_build_orchestrator`
- `bash -n action/1_ios.sh`
- `make doctor`

## 주의사항
- 기존에 워크트리에 있던 `docs/*.md` 변경은 이번 PR에 포함하지 않았습니다.
- Fastlane 레이어는 수정하지 않았고, Python/shell 경계만 정리했습니다.