### PR TITLE
docs: 환경변수 로딩 가이드 갱신

### DIFF
--- a/docs/API_DOCUMENTATION.md
+++ b/docs/API_DOCUMENTATION.md
@@ -11,7 +11,7 @@ Flutter CI/CD Server는 Flutter 애플리케이션의 빌드 파이프라인을 
 pip install -r requirements.txt
 
 # 서버 실행
-uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+./venv/bin/uvicorn src.main:app --host 0.0.0.0 --port 8000 --reload
 ```
 
 ## API 문서 접근

--- a/docs/ENVIRONMENT_LOADING.md
+++ b/docs/ENVIRONMENT_LOADING.md
@@ -3,7 +3,7 @@
 ## 📋 개요
 
 이 프로젝트는 `.env` 파일을 사용하여 환경변수를 관리합니다. 
-**중요:** `main.py`에서 `python-dotenv`를 사용하지 않고, `local_run.sh`에서 환경변수를 로드합니다.
+**중요:** `.env` 파일은 셸 스크립트가 `source` 하지 않습니다. FastAPI 앱 시작 시 `pydantic-settings`가 프로젝트 루트의 `.env`를 읽고, 필요한 값을 `os.environ`으로 미러링합니다.
 
 ---
 
@@ -11,14 +11,10 @@
 
 ### 방법 1: local_run.sh 사용 (권장) ✅
 
-`local_run.sh` 스크립트가 자동으로 `.env` 파일을 로드합니다.
+`local_run.sh`는 가상환경 준비와 의존성 설치를 처리한 뒤 `uvicorn`을 실행합니다. `.env` 파일 자체는 앱 시작 과정에서 Python 설정 계층이 읽습니다.
 
 ```bash
-#!/bin/bash
-# local_run.sh에서 자동 처리
-set -a
-[ -f .env ] && . .env
-set +a
+sh local_run.sh
 ```
 
 **사용법:**
@@ -36,42 +32,39 @@ sh local_run.sh
 
 ### 방법 2: 직접 실행
 
-`.env` 파일을 수동으로 로드한 후 서버를 실행합니다.
+직접 실행해도 루트 `.env`는 자동으로 읽힙니다.
 
 ```bash
-# 1. 환경변수 로드
-export $(cat .env | xargs)
+# 1. 가상환경 활성화
+source venv/bin/activate
 
 # 2. 서버 실행
-uvicorn main:app --reload
+./venv/bin/uvicorn src.main:app --reload
 ```
 
 **주의사항:**
-- ⚠️ `.env` 파일에 줄바꿈이 포함된 값(예: PRIVATE_KEY)이 있으면 문제가 될 수 있습니다.
-- 이 경우 `set -a; source .env; set +a` 사용을 권장합니다.
+- ⚠️ 앱이 자동으로 읽는 대상은 프로젝트 루트의 `.env`입니다.
+- ⚠️ 셸에서 `export $(cat .env | xargs)` 방식으로 수동 로드하면 멀티라인 값이 깨질 수 있습니다.
 
 ---
 
-## 🤔 왜 python-dotenv를 사용하지 않나요?
+## 🤔 왜 별도 셸 로딩을 쓰지 않나요?
 
 ### 이유
 
 1. **중복 방지**: `local_run.sh`에서 이미 환경변수를 로드하고 있습니다.
-2. **의존성 최소화**: 불필요한 Python 패키지를 추가하지 않습니다.
-3. **일관성**: 모든 환경변수 로딩을 한 곳(local_run.sh)에서 관리합니다.
+2. **일관성**: `local_run.sh`와 직접 `uvicorn` 실행 모두 같은 `AppSettings` 경로를 사용합니다.
+3. **안전성**: 멀티라인 값도 `.env` 파서가 그대로 읽을 수 있습니다.
 
 ### 코드 비교
 
-**이전 (python-dotenv 사용):**
+**현재:**
 ```python
-from dotenv import load_dotenv
-load_dotenv()  # 중복!
-```
-
-**현재 (간소화):**
-```python
-# Note: .env 파일은 local_run.sh에서 자동으로 로드됩니다
-# 직접 실행 시: export $(cat .env | xargs) && uvicorn main:app --reload
+model_config = SettingsConfigDict(
+    env_file=(PROJECT_ROOT / ".env", PROJECT_ROOT / "src" / ".env"),
+    env_file_encoding="utf-8",
+    extra="ignore",
+)
 ```
 
 ---
@@ -99,12 +92,7 @@ services:
 서버 시작 시 환경변수가 제대로 로드되었는지 확인:
 
 ```bash
-# 환경변수 출력 (주의: 민감한 정보 포함)
-echo $WORKSPACE_ROOT
-echo $GITHUB_WEBHOOK_SECRET
-
-# 또는 Python에서 확인
-python -c "import os; print(os.environ.get('WORKSPACE_ROOT'))"
+curl http://localhost:8000/diagnostics
 ```
 
 ---
@@ -134,8 +122,9 @@ ls -la .env
 # .env 파일 내용 확인
 cat .env | grep GITHUB_WEBHOOK_SECRET
 
-# local_run.sh 사용
+# 앱 시작 후 진단 확인
 sh local_run.sh
+curl http://localhost:8000/diagnostics
 ```
 
 ### 문제 2: 멀티라인 값 (Private Key) 문제
@@ -156,10 +145,9 @@ MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQg...
 -----END PRIVATE KEY-----"
 ```
 
-그리고 `local_run.sh`를 사용하세요 (더 안전한 파싱).
+그리고 서버는 `local_run.sh` 또는 `./venv/bin/uvicorn src.main:app ...`로 실행하세요. `.env`는 앱이 직접 읽습니다.
 
 ---
 
-**업데이트:** 2025-10-02  
-**버전:** 2.0 (python-dotenv 제거)
-
+**업데이트:** 2026-03-17  
+**버전:** 2.1 (AppSettings 기반 `.env` 로딩 반영)

--- a/docs/ENV_SETUP_GUIDE.md
+++ b/docs/ENV_SETUP_GUIDE.md
@@ -11,7 +11,7 @@ cp env.template .env
 그 다음 `.env` 파일을 열어서 실제 값으로 수정하세요.
 
 **참고:** 
-- `local_run.sh`를 사용하면 `.env` 파일이 자동으로 로드됩니다.
+- `local_run.sh`는 서버 실행만 담당하고, 루트 `.env`는 앱 시작 시 자동으로 읽습니다.
 - 직접 서버를 실행할 경우 루트 `.env`도 자동으로 읽습니다: `./venv/bin/uvicorn src.main:app --reload`
 
 ### 방법 2: 직접 생성
@@ -144,7 +144,7 @@ DEV_FASTLANE_LANE=beta
 서버 시작 시 로그에서 환경변수가 제대로 로드되었는지 확인할 수 있습니다:
 
 ```bash
-uvicorn main:app --reload
+./venv/bin/uvicorn src.main:app --reload
 ```
 
 출력 예시:
@@ -198,7 +198,7 @@ INFO:     ✅ Server ready at http://localhost:8000
 python test_migration.py
 
 # 2. 서버 시작
-uvicorn main:app --reload
+./venv/bin/uvicorn src.main:app --reload
 
 # 3. 테스트 빌드
 curl -X POST "http://localhost:8000/build" \

--- a/docs/MIGRATION_SUMMARY.md
+++ b/docs/MIGRATION_SUMMARY.md
@@ -102,13 +102,12 @@ python test_migration.py
 
 ### 4. 서버 시작
 ```bash
-# 방법 1: local_run.sh 사용 (권장 - .env 자동 로드)
+# 방법 1: local_run.sh 사용 (권장)
 sh local_run.sh
 
 # 방법 2: 직접 실행
 pip install -r requirements.txt
-export $(cat .env | xargs)  # .env 파일 로드
-uvicorn main:app --reload
+./venv/bin/uvicorn src.main:app --reload
 ```
 
 ### 5. 첫 빌드 테스트
@@ -297,4 +296,3 @@ python -c "from cleanup_scheduler import manual_cleanup; manual_cleanup(days=3)"
 **마이그레이션 완료일**: 2025-10-02  
 **담당**: AI Agent  
 **상태**: ✅ 완료
-

--- a/docs/PROCESS.md
+++ b/docs/PROCESS.md
@@ -161,7 +161,7 @@ python monitor.py dev-android-20250102-143022
 **다음 단계:**
 1. 의존성 설치: `pip install -r requirements.txt`
 2. 환경변수 설정 (`.env` 또는 시스템 환경변수)
-3. 서버 시작: `uvicorn main:app --reload`
+3. 서버 시작: `./venv/bin/uvicorn src.main:app --reload`
 4. 테스트 시나리오 실행
 
 ---
@@ -330,8 +330,7 @@ cp env.template .env
 sh local_run.sh
 
 # 방법 2: 직접 실행
-export $(cat .env | xargs)  # .env 파일 로드
-uvicorn main:app --reload
+./venv/bin/uvicorn src.main:app --reload
 ```
 
 ### 4. 첫 빌드 테스트
@@ -405,4 +404,3 @@ ls -la ~/ci-cd-workspace/builds/$BUILD_ID/pub_cache/global_packages/
 ---
 
 **최종 업데이트:** 2025-10-02 (마이그레이션 완료)
-


### PR DESCRIPTION
## 변경 요약
- `.env` 로딩이 셸 `source`가 아니라 `AppSettings` 기반 자동 로딩이라는 점을 문서 전반에 반영했습니다.
- 직접 실행 예시를 현재 엔트리포인트 기준인 `./venv/bin/uvicorn src.main:app ...` 형태로 통일했습니다.
- `local_run.sh` 역할과 진단 확인 절차를 최신 동작에 맞게 정리했습니다.

## 테스트
- 문서 변경만 포함되어 별도 코드 테스트는 실행하지 않았습니다.

## 주의사항
- 코드 변경은 포함하지 않았습니다.
- 이번 PR은 실행 가이드와 환경변수 로딩 설명 정합성만 다룹니다.