### PR TITLE
fix: codesign errSecInternalComponent 해결

### DIFF
--- a/src/internal/infrastructure/platform_toolchain.py
+++ b/src/internal/infrastructure/platform_toolchain.py
@@ -154,6 +154,28 @@ class IOSKeychainPreparer:
         else:
             raise RuntimeError("KEYCHAIN_PASSWORD is required when KEYCHAIN_NAME points to a custom keychain")
 
+        if unlocked_with_password:
+            try:
+                self.command_runner.run_checked(
+                    [
+                        "security", "set-key-partition-list",
+                        "-S", "apple-tool:,apple:,codesign:",
+                        "-s", "-k", keychain_password, keychain_str,
+                    ],
+                    env=context.env,
+                    cwd=str(cwd),
+                    should_stop=should_cancel,
+                )
+            except Exception as exc:
+                if not is_login_keychain:
+                    raise RuntimeError(
+                        f"Failed to set key partition list for '{keychain_name}': {exc}"
+                    ) from exc
+                log(
+                    f"[{build_id}] ⚠️ login keychain partition list update failed; "
+                    "codesign may fail with errSecInternalComponent"
+                )
+
         try:
             self.command_runner.run_checked(
                 ["security", "set-keychain-settings", "-lut", "21600", keychain_str],

--- a/tests/test_setup_executor.py
+++ b/tests/test_setup_executor.py
@@ -77,6 +77,11 @@ def register_login_keychain(
             ["security", "list-keychains", "-d", "user", "-s", "/tmp/other.keychain-db", str(keychain_path.resolve())]
         )
     runner.add_response(["security", "unlock-keychain", "-p", password, str(keychain_path.resolve())])
+    runner.add_response([
+        "security", "set-key-partition-list",
+        "-S", "apple-tool:,apple:,codesign:",
+        "-s", "-k", password, str(keychain_path.resolve()),
+    ])
     runner.add_response(["security", "set-keychain-settings", "-lut", "21600", str(keychain_path.resolve())])
     runner.add_response(["security", "default-keychain", "-d", "user", "-s", str(keychain_path.resolve())])
     return keychain_path
@@ -334,6 +339,11 @@ class SetupExecutorTests(unittest.TestCase):
                 )
 
         self.assertIn(("security", "unlock-keychain", "-p", "secret", str(keychain_path.resolve())), runner.calls)
+        self.assertIn((
+            "security", "set-key-partition-list",
+            "-S", "apple-tool:,apple:,codesign:",
+            "-s", "-k", "secret", str(keychain_path.resolve()),
+        ), runner.calls)
         self.assertIn(("security", "default-keychain", "-d", "user", "-s", str(keychain_path.resolve())), runner.calls)
         self.assertNotIn("KEYCHAIN_PATH", context.env)
         self.assertNotIn("MATCH_KEYCHAIN_NAME", context.env)
@@ -405,6 +415,11 @@ class SetupExecutorTests(unittest.TestCase):
             runner.add_response(["security", "list-keychains", "-d", "user"], stdout="")
             runner.add_response(["security", "list-keychains", "-d", "user", "-s", str(custom_keychain)])
             runner.add_response(["security", "unlock-keychain", "-p", "secret", str(custom_keychain)])
+            runner.add_response([
+                "security", "set-key-partition-list",
+                "-S", "apple-tool:,apple:,codesign:",
+                "-s", "-k", "secret", str(custom_keychain),
+            ])
             runner.add_response(["security", "set-keychain-settings", "-lut", "21600", str(custom_keychain)])
             runner.add_response(["security", "default-keychain", "-d", "user", "-s", str(custom_keychain)])
             runner.add_response(["rbenv", "versions", "--bare"], stdout="3.2.0\n")
@@ -427,6 +442,11 @@ class SetupExecutorTests(unittest.TestCase):
                 )
 
         self.assertIn(("security", "create-keychain", "-p", "secret", str(custom_keychain)), runner.calls)
+        self.assertIn((
+            "security", "set-key-partition-list",
+            "-S", "apple-tool:,apple:,codesign:",
+            "-s", "-k", "secret", str(custom_keychain),
+        ), runner.calls)
         self.assertNotIn("KEYCHAIN_PATH", context.env)
         self.assertNotIn("MATCH_KEYCHAIN_NAME", context.env)
         self.assertNotIn("MATCH_KEYCHAIN_PASSWORD", context.env)


### PR DESCRIPTION
## Summary
- keychain unlock 후 `security set-key-partition-list -S apple-tool:,apple:,codesign:` 호출을 추가하여 codesign이 private key에 접근할 수 있도록 수정
- login keychain에서는 실패 시 경고만 출력, custom keychain에서는 RuntimeError 발생 (기존 에러 처리 패턴과 동일)
- 관련 테스트에 partition list 호출 응답 및 assertion 추가

## Test plan
- [x] `tests/test_setup_executor.py` 전체 통과 (11 tests)
- [x] `python -m compileall src` 통과
- [x] shell syntax check (`bash -n`) 통과
- [ ] CI 서버에서 platform=ios 또는 platform=all 빌드 시 errSecInternalComponent 미발생 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)