### PR TITLE
fix: 임시 키체인 기본 전략 적용

### DIFF
--- a/src/internal/application/build_orchestrator.py
+++ b/src/internal/application/build_orchestrator.py
@@ -164,6 +164,12 @@ class BuildOrchestrator:
             logger.exception("Build pipeline failed for %s", job.build_id)
             self.repository.save(job)
         finally:
+            if runtime:
+                for cleanup in reversed(runtime.cleanup_callbacks):
+                    try:
+                        cleanup()
+                    except Exception as exc:
+                        self._log(job, f"[{job.build_id}] ⚠️ Runtime cleanup failed: {exc}")
             if runtime and runtime.workspace_lease is not None:
                 runtime.workspace_lease.release()
                 self._log(job, f"[{job.build_id}] 🔓 Workspace slot released: {runtime.slot_key}/{runtime.slot_id}")

--- a/src/internal/application/config_diagnostics.py
+++ b/src/internal/application/config_diagnostics.py
@@ -32,7 +32,6 @@ class ConfigDiagnostics:
 
     IOS_BUILD_VARS = [
         "MATCH_PASSWORD",
-        "KEYCHAIN_NAME",
     ]
 
     def __init__(self) -> None:
@@ -64,6 +63,8 @@ class ConfigDiagnostics:
 
         if request.platform in {"all", "ios"}:
             required.extend(self.IOS_BUILD_VARS)
+            if self._keychain_strategy() == "configured":
+                required.append("KEYCHAIN_NAME")
 
         missing = self._find_missing(required)
 
@@ -144,6 +145,12 @@ class ConfigDiagnostics:
         """Validate macOS keychain readiness for iOS codesigning."""
         missing: List[str] = []
         details: Dict[str, str] = {}
+        strategy = self._keychain_strategy()
+        details["strategy"] = strategy
+
+        if strategy == "ephemeral":
+            details["keychain_name"] = "generated per build"
+            return DiagnosticResult(feature="keychain", ready=True, missing=missing, details=details)
 
         keychain_name = (os.environ.get("KEYCHAIN_NAME") or "").strip()
         keychain_password = os.environ.get("KEYCHAIN_PASSWORD", "")
@@ -230,8 +237,7 @@ class ConfigDiagnostics:
             "github_action": self.get_github_action_diagnostics(),
             "shorebird_action": self.get_shorebird_action_diagnostics(),
         }
-        keychain_name = (os.environ.get("KEYCHAIN_NAME") or "").strip()
-        if keychain_name:
+        if self._keychain_strategy() in {"configured", "ephemeral"}:
             results["keychain"] = self.get_keychain_diagnostics()
         return results
 
@@ -254,3 +260,9 @@ class ConfigDiagnostics:
 
     def _find_missing(self, keys: List[str]) -> List[str]:
         return [key for key in keys if not os.environ.get(key)]
+
+    def _keychain_strategy(self) -> str:
+        configured = (os.environ.get("IOS_KEYCHAIN_STRATEGY") or "").strip().lower()
+        if configured in {"configured", "ephemeral"}:
+            return configured
+        return "configured" if (os.environ.get("KEYCHAIN_NAME") or "").strip() else "ephemeral"

--- a/src/internal/core/build_runtime.py
+++ b/src/internal/core/build_runtime.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional
 
 
 @dataclass
@@ -19,6 +19,7 @@ class BuildRuntimeContext:
     slot_key: Optional[str] = None
     slot_id: Optional[str] = None
     workspace_lease: Optional[Any] = None
+    cleanup_callbacks: list[Callable[[], None]] = field(default_factory=list)
 
     def is_shorebird_patch(self) -> bool:
         return self.trigger_source.startswith("shorebird")

--- a/src/internal/infrastructure/platform_toolchain.py
+++ b/src/internal/infrastructure/platform_toolchain.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import platform
+import secrets
 import shutil
 from pathlib import Path
 from typing import Dict
@@ -88,6 +89,9 @@ class ShorebirdCacheValidator:
 class PreparedKeychain:
     path: Path
     password: str | None
+    search_list: list[str]
+    original_default_keychain: str | None
+    ephemeral: bool = False
 
     def match_name(self) -> str:
         keychain_dir = (Path.home() / "Library" / "Keychains").resolve()
@@ -110,16 +114,33 @@ class IOSKeychainPreparer:
         This method only performs the per-build runtime steps: unlock, register
         in the search list, and set as default.
         """
+        strategy = self._strategy(context)
         keychain_name = (context.env.get("KEYCHAIN_NAME") or "").strip()
         keychain_password = context.env.get("KEYCHAIN_PASSWORD")
-        if not keychain_name:
-            raise RuntimeError("KEYCHAIN_NAME is required for iOS signing environment preparation")
-
-        keychain_path = self._resolve_keychain_path(keychain_name) or self._planned_keychain_path(keychain_name)
-        if keychain_path is None:
-            raise RuntimeError(f"Configured keychain '{keychain_name}' could not be resolved")
+        if strategy == "ephemeral":
+            keychain_path, keychain_password = self._create_ephemeral_keychain(
+                build_id,
+                context,
+                cwd,
+                log,
+                should_cancel=should_cancel,
+            )
+        else:
+            if not keychain_name:
+                raise RuntimeError("KEYCHAIN_NAME is required for iOS signing environment preparation")
+            keychain_path = self._resolve_keychain_path(keychain_name) or self._planned_keychain_path(keychain_name)
+            if keychain_path is None:
+                raise RuntimeError(f"Configured keychain '{keychain_name}' could not be resolved")
 
         keychain_str = str(keychain_path)
+        default_keychain = self.command_runner.run(
+            ["security", "default-keychain", "-d", "user"],
+            env=context.env,
+            cwd=str(cwd),
+            check=False,
+            should_stop=should_cancel,
+        )
+        original_default_keychain = self._parse_default_keychain(default_keychain.stdout)
 
         # Ensure keychain is in the search list
         existing = self.command_runner.run(
@@ -157,7 +178,13 @@ class IOSKeychainPreparer:
         )
         log(f"[{build_id}] 🔐 Keychain ready: {keychain_path.name}")
         normalized_password = keychain_password.strip() if isinstance(keychain_password, str) else keychain_password
-        return PreparedKeychain(path=keychain_path, password=normalized_password or None)
+        return PreparedKeychain(
+            path=keychain_path,
+            password=normalized_password or None,
+            search_list=search_list,
+            original_default_keychain=original_default_keychain,
+            ephemeral=(strategy == "ephemeral"),
+        )
 
     def _resolve_keychain_path(self, keychain_name: str) -> Path | None:
         provided = Path(keychain_name).expanduser()
@@ -203,9 +230,49 @@ class IOSKeychainPreparer:
                 parsed.append(str(Path(stripped).expanduser()))
         return parsed
 
+    def _parse_default_keychain(self, output: str) -> str | None:
+        for line in output.splitlines():
+            stripped = line.strip().strip('"')
+            if stripped:
+                return str(Path(stripped).expanduser())
+        return None
+
     def _is_login_keychain(self, keychain_path: Path) -> bool:
         name = keychain_path.name
         return name in {"login.keychain", "login.keychain-db"}
+
+    def _strategy(self, context: BuildRuntimeContext) -> str:
+        configured = (context.env.get("IOS_KEYCHAIN_STRATEGY") or "").strip().lower()
+        if configured in {"configured", "ephemeral"}:
+            return configured
+        return "configured" if (context.env.get("KEYCHAIN_NAME") or "").strip() else "ephemeral"
+
+    def _create_ephemeral_keychain(
+        self,
+        build_id: str,
+        context: BuildRuntimeContext,
+        cwd: Path,
+        log,
+        should_cancel=None,
+    ) -> tuple[Path, str]:
+        keychain_dir = Path(context.workspace) / "keychains"
+        keychain_dir.mkdir(parents=True, exist_ok=True)
+        keychain_path = (keychain_dir / f"{build_id}.keychain-db").resolve()
+        keychain_password = secrets.token_urlsafe(24)
+        self.command_runner.run_checked(
+            ["security", "create-keychain", "-p", keychain_password, str(keychain_path)],
+            env=context.env,
+            cwd=str(cwd),
+            should_stop=should_cancel,
+        )
+        self.command_runner.run_checked(
+            ["security", "set-keychain-settings", "-lut", "21600", str(keychain_path)],
+            env=context.env,
+            cwd=str(cwd),
+            should_stop=should_cancel,
+        )
+        log(f"[{build_id}] 🔐 Created ephemeral keychain: {keychain_path.name}")
+        return keychain_path, keychain_password
 
 
 class PlatformToolchainPreparer:
@@ -276,6 +343,7 @@ class PlatformToolchainPreparer:
             should_cancel=should_cancel,
         )
         self._configure_fastlane_keychain_env(build_id, context, prepared_keychain, log)
+        self._register_keychain_cleanup(build_id, context, ios_dir, prepared_keychain, log)
         self._prepare_flutter_ios_artifacts(build_id, context, ios_dir, log, should_cancel=should_cancel)
         self._plan_ios_pod_install(build_id, context, ios_dir, log)
         self.ruby_toolchain.configure_environment(ios_dir, context.env, build_id, log, should_cancel=should_cancel)
@@ -310,18 +378,20 @@ class PlatformToolchainPreparer:
         self.ruby_toolchain.install_fastlane_plugins(ios_dir, context.env, build_id, log, should_cancel=should_cancel)
 
     def _validate_ios_runtime_requirements(self, build_id: str, context: BuildRuntimeContext, log) -> None:
-        keychain_name = (context.env.get("KEYCHAIN_NAME") or "").strip()
-        if not keychain_name:
-            raise RuntimeError("KEYCHAIN_NAME is required for iOS builds")
+        strategy = self.ios_keychain._strategy(context)
+        if strategy == "configured":
+            keychain_name = (context.env.get("KEYCHAIN_NAME") or "").strip()
+            if not keychain_name:
+                raise RuntimeError("KEYCHAIN_NAME is required for iOS builds")
 
-        keychain_password = context.env.get("KEYCHAIN_PASSWORD", "").strip()
-        keychain_path = (
-            self.ios_keychain._resolve_keychain_path(keychain_name)
-            or self.ios_keychain._planned_keychain_path(keychain_name)
-        )
-        is_login_keychain = bool(keychain_path and self.ios_keychain._is_login_keychain(keychain_path))
-        if not is_login_keychain and not keychain_password:
-            raise RuntimeError("KEYCHAIN_PASSWORD is required when KEYCHAIN_NAME points to a custom keychain")
+            keychain_password = context.env.get("KEYCHAIN_PASSWORD", "").strip()
+            keychain_path = (
+                self.ios_keychain._resolve_keychain_path(keychain_name)
+                or self.ios_keychain._planned_keychain_path(keychain_name)
+            )
+            is_login_keychain = bool(keychain_path and self.ios_keychain._is_login_keychain(keychain_path))
+            if not is_login_keychain and not keychain_password:
+                raise RuntimeError("KEYCHAIN_PASSWORD is required when KEYCHAIN_NAME points to a custom keychain")
 
         match_password = (context.env.get("MATCH_PASSWORD") or "").strip()
         if not match_password:
@@ -368,6 +438,42 @@ class PlatformToolchainPreparer:
             f"[{build_id}] ⚠️ Fastlane match keychain password is unavailable for "
             f"{context.env['MATCH_KEYCHAIN_NAME']}; the Fastfile must tolerate an existing session"
         )
+
+    def _register_keychain_cleanup(
+        self,
+        build_id: str,
+        context: BuildRuntimeContext,
+        cwd: Path,
+        prepared_keychain: PreparedKeychain,
+        log,
+    ) -> None:
+        if not prepared_keychain.ephemeral:
+            return
+
+        def cleanup() -> None:
+            if prepared_keychain.original_default_keychain:
+                self.command_runner.run(
+                    ["security", "default-keychain", "-d", "user", "-s", prepared_keychain.original_default_keychain],
+                    env=context.env,
+                    cwd=str(cwd),
+                    check=False,
+                )
+            if prepared_keychain.search_list:
+                self.command_runner.run(
+                    ["security", "list-keychains", "-d", "user", "-s", *prepared_keychain.search_list],
+                    env=context.env,
+                    cwd=str(cwd),
+                    check=False,
+                )
+            self.command_runner.run(
+                ["security", "delete-keychain", str(prepared_keychain.path)],
+                env=context.env,
+                cwd=str(cwd),
+                check=False,
+            )
+            log(f"[{build_id}] 🧹 Removed ephemeral keychain: {prepared_keychain.path.name}")
+
+        context.cleanup_callbacks.append(cleanup)
 
     def _prepare_flutter_ios_artifacts(
         self,

--- a/tests/test_build_orchestrator.py
+++ b/tests/test_build_orchestrator.py
@@ -101,6 +101,47 @@ class BuildOrchestratorTests(unittest.TestCase):
         self.assertEqual("2.2.1", started_env["BUILD_NAME"])
         self.assertEqual("693", started_env["BUILD_NUMBER"])
 
+    def test_run_pipeline_executes_runtime_cleanup_callbacks(self) -> None:
+        repository = StubRepository()
+        command_runner = CapturingCommandRunner()
+        cleanup_calls: list[str] = []
+
+        class StubVersionResolver:
+            def resolve(self, request):
+                return request
+
+        class StubEnvironmentAssembler:
+            def assemble(self, job, versions, log, should_cancel=None):
+                runtime = BuildRuntimeContext(
+                    env={},
+                    repo_dir="/tmp/repo",
+                    workspace="/tmp/workspace",
+                )
+                runtime.cleanup_callbacks.append(lambda: cleanup_calls.append(job.build_id))
+                return runtime
+
+        orchestrator = BuildOrchestrator(
+            repository=repository,
+            validator=None,
+            version_resolver=StubVersionResolver(),
+            command_runner=command_runner,
+            config_diagnostics=None,
+            environment_assembler=StubEnvironmentAssembler(),
+            setup_executor=StubSetupExecutor(),
+            status_presenter=None,
+        )
+
+        request = BuildRequestData(
+            flavor="dev",
+            platform="ios",
+            branch_name="develop",
+        )
+        job = BuildJob.create("build-cleanup", request, "develop", "queue-cleanup")
+
+        orchestrator._run_pipeline(job, request)
+
+        self.assertEqual(["build-cleanup"], cleanup_calls)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_setup_executor.py
+++ b/tests/test_setup_executor.py
@@ -76,6 +76,7 @@ def register_login_keychain(
         runner.add_response(
             ["security", "list-keychains", "-d", "user", "-s", "/tmp/other.keychain-db", str(keychain_path.resolve())]
         )
+    runner.add_response(["security", "default-keychain", "-d", "user"], stdout=f"    \"{keychain_path.resolve()}\"\n")
     runner.add_response(["security", "unlock-keychain", "-p", password, str(keychain_path.resolve())])
     runner.add_response([
         "security", "set-key-partition-list",
@@ -212,6 +213,7 @@ class SetupExecutorTests(unittest.TestCase):
         self.assertEqual("/tmp/gems/ruby-3.2.0", context.env["GEM_HOME"])
         self.assertEqual("/tmp/gems/ruby-3.2.0/bundle", context.env["BUNDLE_PATH"])
         self.assertEqual("true", context.env["IOS_SHOULD_RUN_POD_INSTALL"])
+        self.assertEqual(0, len(context.cleanup_callbacks))
 
     def test_prepare_ios_toolchain_exports_fastlane_match_keychain_env(self) -> None:
         runner = FakeCommandRunner()
@@ -248,6 +250,7 @@ class SetupExecutorTests(unittest.TestCase):
         self.assertEqual("secret", context.env["MATCH_KEYCHAIN_PASSWORD"])
         self.assertEqual(keychain_path.name, context.env["KEYCHAIN_NAME"])
         self.assertEqual("secret", context.env["KEYCHAIN_PASSWORD"])
+        self.assertEqual(0, len(context.cleanup_callbacks))
         self.assertTrue(any("Fastlane match will use keychain" in line for line in logs))
 
     def test_prepare_ios_toolchain_prepares_standalone_fastlane_for_shorebird_patch(self) -> None:
@@ -450,7 +453,7 @@ class SetupExecutorTests(unittest.TestCase):
             create_flutter_ios_artifact(repo_dir)
 
             custom_keychain = Path(home) / "Library" / "Keychains" / "ppb_ci_signing.keychain-db"
-            runner.add_response(["security", "create-keychain", "-p", "secret", str(custom_keychain)])
+            runner.add_response(["security", "default-keychain", "-d", "user"], stdout="    \"/tmp/original.keychain-db\"\n")
             runner.add_response(["security", "list-keychains", "-d", "user"], stdout="")
             runner.add_response(["security", "list-keychains", "-d", "user", "-s", str(custom_keychain)])
             runner.add_response(["security", "unlock-keychain", "-p", "secret", str(custom_keychain)])
@@ -487,6 +490,46 @@ class SetupExecutorTests(unittest.TestCase):
         self.assertEqual("ppb_ci_signing.keychain-db", context.env["MATCH_KEYCHAIN_NAME"])
         self.assertEqual("secret", context.env["MATCH_KEYCHAIN_PASSWORD"])
         self.assertTrue(any("Fastlane match will use keychain" in line for line in logs))
+
+    def test_prepare_ios_toolchain_creates_ephemeral_keychain_when_name_missing(self) -> None:
+        runner = FakeCommandRunner()
+        executor = SetupExecutor(runner)
+        logs: list[str] = []
+
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_dir = Path(tmp) / "repo"
+            ios_dir = repo_dir / "ios"
+            ios_dir.mkdir(parents=True)
+            create_flutter_ios_artifact(repo_dir)
+            ephemeral_path = (Path(tmp) / "keychains" / "build-ephemeral.keychain-db").resolve()
+            runner.add_response(["security", "default-keychain", "-d", "user"], stdout="    \"/tmp/original.keychain-db\"\n")
+            runner.add_response(["security", "set-keychain-settings", "-lut", "21600", str(ephemeral_path)])
+            runner.add_response(["security", "list-keychains", "-d", "user"], stdout="    \"/tmp/original.keychain-db\"\n")
+            runner.add_response(["security", "list-keychains", "-d", "user", "-s", "/tmp/original.keychain-db", str(ephemeral_path)])
+            runner.add_response(["security", "default-keychain", "-d", "user", "-s", str(ephemeral_path)])
+            runner.add_response(["rbenv", "versions", "--bare"], stdout="3.2.0\n")
+            runner.add_response(["ruby", "-e", "print RUBY_VERSION"], stdout="3.2.0")
+            runner.add_response(["gem", "list", "-i", "cocoapods"], returncode=0)
+            runner.add_response(["gem", "list", "-i", "fastlane"], returncode=0)
+
+            context = BuildRuntimeContext(
+                env=default_ios_env(KEYCHAIN_NAME="", KEYCHAIN_PASSWORD=""),
+                repo_dir=str(repo_dir),
+                workspace=tmp,
+            )
+            executor.prepare_platform_toolchain(
+                build_id="build-ephemeral",
+                platform="ios",
+                context=context,
+                log=logs.append,
+            )
+
+        self.assertEqual(str(ephemeral_path), context.env["KEYCHAIN_NAME"])
+        self.assertEqual(str(ephemeral_path), context.env["MATCH_KEYCHAIN_NAME"])
+        self.assertTrue(context.env["KEYCHAIN_PASSWORD"])
+        self.assertTrue(context.env["MATCH_KEYCHAIN_PASSWORD"])
+        self.assertEqual(1, len(context.cleanup_callbacks))
+        self.assertTrue(any("Created ephemeral keychain" in line for line in logs))
 
     def test_prepare_ios_toolchain_repairs_missing_flutter_artifact_before_fastlane(self) -> None:
         runner = FakeCommandRunner()


### PR DESCRIPTION
## 변경 요약
- `KEYCHAIN_NAME`이 비어 있으면 빌드별 ephemeral keychain을 생성하도록 변경했습니다.
- iOS 빌드 종료 시 default keychain/search list를 원복하고 임시 keychain을 삭제하도록 cleanup을 추가했습니다.
- keychain diagnostics와 관련 테스트를 새 기본 전략에 맞게 갱신했습니다.

## 테스트 / 검증
- `make doctor`
- `make test`

## 주의사항
- 이제 `.env`에서 `KEYCHAIN_NAME`을 비워두면 서버가 빌드마다 임시 keychain을 생성합니다.
- Matchfile이 다른 저장소에 있는 경우에도 서버가 `KEYCHAIN_*`와 `MATCH_KEYCHAIN_*`를 함께 주입하므로 둘 중 어느 env를 읽더라도 같은 값을 보게 됩니다.
- 실제 앱 저장소의 Fastfile/Matchfile은 fallback 또는 공통 env 규칙으로 별도 정리하는 것이 좋습니다.