### PR TITLE
fix: 임시 키체인 startup 진단 보정

### DIFF
--- a/src/core/app.py
+++ b/src/core/app.py
@@ -45,11 +45,6 @@ def _log_startup_details(settings: AppSettings, diagnostics: ConfigDiagnostics) 
 
 
 def _validate_keychain_at_startup(diagnostics: ConfigDiagnostics) -> None:
-    keychain_name = (os.environ.get("KEYCHAIN_NAME") or "").strip()
-    if not keychain_name:
-        logger.info("KEYCHAIN_NAME not set — keychain validation skipped (iOS builds will be rejected)")
-        return
-
     result = diagnostics.validate_keychain_on_startup()
     for key, value in result.details.items():
         logger.info("Keychain %s: %s", key, value)

--- a/src/internal/application/config_diagnostics.py
+++ b/src/internal/application/config_diagnostics.py
@@ -49,6 +49,8 @@ class ConfigDiagnostics:
     @property
     def keychain_ready(self) -> bool:
         """Whether the keychain was validated successfully at startup."""
+        if self._keychain_strategy() == "ephemeral":
+            return True
         return self._keychain_result is not None and self._keychain_result.ready
 
     def get_build_diagnostics(self, request: BuildRequestData) -> DiagnosticResult:

--- a/tests/test_config_diagnostics.py
+++ b/tests/test_config_diagnostics.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from src.internal.application.config_diagnostics import ConfigDiagnostics
+from src.internal.domain import BuildRequestData
+
+
+class ConfigDiagnosticsTests(unittest.TestCase):
+    def test_ephemeral_keychain_strategy_is_ready_without_startup_cache(self) -> None:
+        diagnostics = ConfigDiagnostics()
+
+        with patch.dict(
+            os.environ,
+            {
+                "REPO_URL": "git@github.com:org/app.git",
+                "DEV_FASTLANE_LANE": "beta",
+                "DEV_BRANCH_NAME": "develop",
+                "MATCH_PASSWORD": "match-secret",
+            },
+            clear=True,
+        ):
+            result = diagnostics.get_build_diagnostics(
+                BuildRequestData(flavor="dev", platform="ios", branch_name="develop")
+            )
+
+        self.assertTrue(result.ready)
+        self.assertNotIn("keychain: keychain not validated at startup", result.missing)
+
+    def test_validate_keychain_on_startup_succeeds_for_ephemeral_strategy(self) -> None:
+        diagnostics = ConfigDiagnostics()
+
+        with patch.dict(os.environ, {}, clear=True):
+            result = diagnostics.validate_keychain_on_startup()
+
+        self.assertTrue(result.ready)
+        self.assertEqual("ephemeral", result.details["strategy"])
+        self.assertEqual([], result.missing)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 요약
- `KEYCHAIN_NAME`이 비어 있을 때 startup keychain validation을 건너뛰지 않고 ephemeral 전략으로 성공 상태를 캐시하도록 수정했습니다.
- iOS build diagnostics가 `keychain not validated at startup` 오류로 잘못 차단하지 않도록 보정했습니다.
- 관련 회귀 테스트를 추가했습니다.

## 테스트 / 검증
- `make test`
- `make doctor`

## 배경
- PR #42 merge 이후 `KEYCHAIN_NAME`을 비운 환경에서 `/build` 요청이 `keychain: keychain not validated at startup`로 차단되는 문제가 있었습니다.
- 이번 PR은 그 startup/build diagnostics 불일치를 수정합니다.