### PR TITLE
fix: iOS 코드사인 키체인 준비 보강

### DIFF
--- a/src/internal/application/config_diagnostics.py
+++ b/src/internal/application/config_diagnostics.py
@@ -186,12 +186,10 @@ class ConfigDiagnostics:
                 details["unlock"] = "ok"
             else:
                 details["unlock"] = f"failed (exit {result.returncode})"
-                if not is_login:
-                    missing.append("keychain unlock failed with KEYCHAIN_PASSWORD")
-        elif is_login:
-            details["unlock"] = "skipped (no KEYCHAIN_PASSWORD; relies on user session)"
+                missing.append("keychain unlock failed with KEYCHAIN_PASSWORD")
         else:
-            missing.append("KEYCHAIN_PASSWORD (required for non-login keychain)")
+            details["unlock"] = "skipped (missing KEYCHAIN_PASSWORD)"
+            missing.append("KEYCHAIN_PASSWORD (required for configured keychain)")
 
         # --- partition list test ---
         if unlock_ok and keychain_password:

--- a/src/internal/infrastructure/platform_toolchain.py
+++ b/src/internal/infrastructure/platform_toolchain.py
@@ -103,16 +103,21 @@ class PreparedKeychain:
 class IOSKeychainPreparer:
     """Unlock and register the macOS keychain used by iOS signing."""
 
+    _KEYCHAIN_UNLOCK_TIMEOUT_SECONDS = "21600"
+    _PARTITION_LIST_SERVICES = "apple-tool:,apple:,codesign:"
+
     def __init__(self, command_runner: CommandRunner) -> None:
         self.command_runner = command_runner
 
     def prepare(self, build_id: str, context: BuildRuntimeContext, cwd: Path, log, should_cancel=None) -> PreparedKeychain:
         """Ensure the keychain is unlocked and registered for this build.
 
-        Heavy validation (existence, partition-list, codesign identities) is
-        performed once at server startup via ``ConfigDiagnostics.validate_keychain_on_startup``.
-        This method only performs the per-build runtime steps: unlock, register
-        in the search list, and set as default.
+        Heavy validation (existence and codesigning identities) is performed
+        once at server startup via ``ConfigDiagnostics.validate_keychain_on_startup``.
+        This method performs the per-build runtime steps that must be refreshed
+        for each archive session: unlock, extend the auto-lock timeout, apply
+        the partition list for non-interactive codesign, register in the search
+        list, and set as default.
         """
         strategy = self._strategy(context)
         keychain_name = (context.env.get("KEYCHAIN_NAME") or "").strip()
@@ -142,6 +147,14 @@ class IOSKeychainPreparer:
         )
         original_default_keychain = self._parse_default_keychain(default_keychain.stdout)
 
+        # Ensure keychain remains available for long-running archive sessions.
+        self.command_runner.run_checked(
+            ["security", "set-keychain-settings", "-lut", self._KEYCHAIN_UNLOCK_TIMEOUT_SECONDS, keychain_str],
+            env=context.env,
+            cwd=str(cwd),
+            should_stop=should_cancel,
+        )
+
         # Ensure keychain is in the search list
         existing = self.command_runner.run(
             ["security", "list-keychains", "-d", "user"],
@@ -164,6 +177,21 @@ class IOSKeychainPreparer:
         if keychain_password:
             self.command_runner.run_checked(
                 ["security", "unlock-keychain", "-p", keychain_password, keychain_str],
+                env=context.env,
+                cwd=str(cwd),
+                should_stop=should_cancel,
+            )
+            self.command_runner.run_checked(
+                [
+                    "security",
+                    "set-key-partition-list",
+                    "-S",
+                    self._PARTITION_LIST_SERVICES,
+                    "-s",
+                    "-k",
+                    keychain_password,
+                    keychain_str,
+                ],
                 env=context.env,
                 cwd=str(cwd),
                 should_stop=should_cancel,
@@ -389,9 +417,12 @@ class PlatformToolchainPreparer:
                 self.ios_keychain._resolve_keychain_path(keychain_name)
                 or self.ios_keychain._planned_keychain_path(keychain_name)
             )
-            is_login_keychain = bool(keychain_path and self.ios_keychain._is_login_keychain(keychain_path))
-            if not is_login_keychain and not keychain_password:
-                raise RuntimeError("KEYCHAIN_PASSWORD is required when KEYCHAIN_NAME points to a custom keychain")
+            if not keychain_password:
+                resolved_name = keychain_path.name if keychain_path else keychain_name
+                raise RuntimeError(
+                    "KEYCHAIN_PASSWORD is required for configured iOS keychains "
+                    f"to enable non-interactive codesigning ({resolved_name})"
+                )
 
         match_password = (context.env.get("MATCH_PASSWORD") or "").strip()
         if not match_password:

--- a/tests/test_config_diagnostics.py
+++ b/tests/test_config_diagnostics.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
+from pathlib import Path
+from subprocess import CompletedProcess
 from unittest.mock import patch
 
 from src.internal.application.config_diagnostics import ConfigDiagnostics
@@ -38,6 +41,38 @@ class ConfigDiagnosticsTests(unittest.TestCase):
         self.assertTrue(result.ready)
         self.assertEqual("ephemeral", result.details["strategy"])
         self.assertEqual([], result.missing)
+
+    def test_validate_keychain_on_startup_requires_password_for_configured_keychain(self) -> None:
+        diagnostics = ConfigDiagnostics()
+
+        with tempfile.TemporaryDirectory() as home:
+            keychain_dir = Path(home) / "Library" / "Keychains"
+            keychain_dir.mkdir(parents=True, exist_ok=True)
+            (keychain_dir / "login.keychain-db").write_text("", encoding="utf-8")
+
+            with (
+                patch.dict(
+                    os.environ,
+                    {
+                        "KEYCHAIN_NAME": "login.keychain",
+                        "KEYCHAIN_PASSWORD": "",
+                    },
+                    clear=True,
+                ),
+                patch("pathlib.Path.home", return_value=Path(home)),
+                patch(
+                    "subprocess.run",
+                    return_value=CompletedProcess(
+                        args=["security", "find-identity"],
+                        returncode=0,
+                        stdout="  1) ABCDEF1234567890 \"Apple Distribution: Example\"\n     1 valid identities found\n",
+                    ),
+                ),
+            ):
+                result = diagnostics.validate_keychain_on_startup()
+
+        self.assertFalse(result.ready)
+        self.assertIn("KEYCHAIN_PASSWORD (required for configured keychain)", result.missing)
 
 
 if __name__ == "__main__":

--- a/tests/test_setup_executor.py
+++ b/tests/test_setup_executor.py
@@ -382,7 +382,21 @@ class SetupExecutorTests(unittest.TestCase):
                     log=logs.append,
                 )
 
+        self.assertIn(("security", "set-keychain-settings", "-lut", "21600", str(keychain_path.resolve())), runner.calls)
         self.assertIn(("security", "unlock-keychain", "-p", "secret", str(keychain_path.resolve())), runner.calls)
+        self.assertIn(
+            (
+                "security",
+                "set-key-partition-list",
+                "-S",
+                "apple-tool:,apple:,codesign:",
+                "-s",
+                "-k",
+                "secret",
+                str(keychain_path.resolve()),
+            ),
+            runner.calls,
+        )
         self.assertIn(("security", "default-keychain", "-d", "user", "-s", str(keychain_path.resolve())), runner.calls)
         self.assertNotIn("KEYCHAIN_PATH", context.env)
         self.assertEqual("login.keychain-db", context.env["KEYCHAIN_NAME"])
@@ -438,6 +452,38 @@ class SetupExecutorTests(unittest.TestCase):
         self.assertNotIn(("security", "default-keychain", "-d", "user", "-s", str(keychain_path.resolve())), runner.calls)
         self.assertEqual("login.keychain", context.env["KEYCHAIN_NAME"])
         self.assertEqual("wrong-secret", context.env["KEYCHAIN_PASSWORD"])
+        self.assertNotIn("MATCH_KEYCHAIN_NAME", context.env)
+        self.assertNotIn("MATCH_KEYCHAIN_PASSWORD", context.env)
+
+    def test_prepare_ios_toolchain_fails_when_configured_keychain_password_missing(self) -> None:
+        runner = FakeCommandRunner()
+        executor = SetupExecutor(runner)
+
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as home:
+            register_login_keychain(runner, Path(home))
+            repo_dir = Path(tmp) / "repo"
+            ios_dir = repo_dir / "ios"
+            ios_dir.mkdir(parents=True)
+            create_flutter_ios_artifact(repo_dir)
+
+            context = BuildRuntimeContext(
+                env=default_ios_env(KEYCHAIN_PASSWORD=""),
+                repo_dir=str(repo_dir),
+                workspace=tmp,
+            )
+
+            with patch("pathlib.Path.home", return_value=Path(home)):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "KEYCHAIN_PASSWORD is required for configured iOS keychains",
+                ):
+                    executor.prepare_platform_toolchain(
+                        build_id="build-missing-keychain-password",
+                        platform="ios",
+                        context=context,
+                        log=lambda _: None,
+                    )
+
         self.assertNotIn("MATCH_KEYCHAIN_NAME", context.env)
         self.assertNotIn("MATCH_KEYCHAIN_PASSWORD", context.env)
 


### PR DESCRIPTION
## 변경 요약
- configured iOS keychain 준비 단계에서 `set-keychain-settings -lut 21600`과 `set-key-partition-list`를 빌드마다 강제하도록 수정했습니다.
- configured keychain은 `KEYCHAIN_PASSWORD` 없이는 진행하지 않도록 런타임/시작 진단 기준을 일치시켰습니다.
- keychain 준비와 진단 회귀 테스트를 추가했습니다.

## 테스트
- `make doctor`
- `make test`

## 주의사항
- 서버 재시작 후 startup diagnostics가 새 기준으로 다시 실행되어야 합니다.
- configured keychain을 쓰는 환경에서는 `KEYCHAIN_PASSWORD`가 반드시 설정돼 있어야 합니다.

## 참고
- 커밋: `1452913`
- 증상: `Flutter.framework` 및 native asset codesign 단계의 `errSecInternalComponent`