### PR TITLE
fix: 임시 keychain partition 설정 수정

### DIFF
--- a/src/internal/infrastructure/platform_toolchain.py
+++ b/src/internal/infrastructure/platform_toolchain.py
@@ -115,9 +115,11 @@ class IOSKeychainPreparer:
         Heavy validation (existence and codesigning identities) is performed
         once at server startup via ``ConfigDiagnostics.validate_keychain_on_startup``.
         This method performs the per-build runtime steps that must be refreshed
-        for each archive session: unlock, extend the auto-lock timeout, apply
-        the partition list for non-interactive codesign, register in the search
-        list, and set as default.
+        for each archive session: unlock, extend the auto-lock timeout,
+        register in the search list, and set as default.
+        For ephemeral keychains, Fastlane imports the signing identity later,
+        so applying the partition list here would fail before any private key
+        exists in the new keychain.
         """
         strategy = self._strategy(context)
         keychain_name = (context.env.get("KEYCHAIN_NAME") or "").strip()
@@ -181,21 +183,22 @@ class IOSKeychainPreparer:
                 cwd=str(cwd),
                 should_stop=should_cancel,
             )
-            self.command_runner.run_checked(
-                [
-                    "security",
-                    "set-key-partition-list",
-                    "-S",
-                    self._PARTITION_LIST_SERVICES,
-                    "-s",
-                    "-k",
-                    keychain_password,
-                    keychain_str,
-                ],
-                env=context.env,
-                cwd=str(cwd),
-                should_stop=should_cancel,
-            )
+            if strategy != "ephemeral":
+                self.command_runner.run_checked(
+                    [
+                        "security",
+                        "set-key-partition-list",
+                        "-S",
+                        self._PARTITION_LIST_SERVICES,
+                        "-s",
+                        "-k",
+                        keychain_password,
+                        keychain_str,
+                    ],
+                    env=context.env,
+                    cwd=str(cwd),
+                    should_stop=should_cancel,
+                )
 
         # Set as default keychain
         self.command_runner.run_checked(

--- a/tests/test_setup_executor.py
+++ b/tests/test_setup_executor.py
@@ -574,6 +574,20 @@ class SetupExecutorTests(unittest.TestCase):
         self.assertEqual(str(ephemeral_path), context.env["MATCH_KEYCHAIN_NAME"])
         self.assertTrue(context.env["KEYCHAIN_PASSWORD"])
         self.assertTrue(context.env["MATCH_KEYCHAIN_PASSWORD"])
+        self.assertIn(("security", "unlock-keychain", "-p", context.env["KEYCHAIN_PASSWORD"], str(ephemeral_path)), runner.calls)
+        self.assertNotIn(
+            (
+                "security",
+                "set-key-partition-list",
+                "-S",
+                "apple-tool:,apple:,codesign:",
+                "-s",
+                "-k",
+                context.env["KEYCHAIN_PASSWORD"],
+                str(ephemeral_path),
+            ),
+            runner.calls,
+        )
         self.assertEqual(1, len(context.cleanup_callbacks))
         self.assertTrue(any("Created ephemeral keychain" in line for line in logs))
 


### PR DESCRIPTION
## 변경 요약
- ephemeral keychain 생성 직후 `set-key-partition-list`를 호출하지 않도록 조정했습니다.
- configured keychain의 기존 unlock/partition list 동작은 유지했습니다.
- ephemeral keychain 경로에서 partition list 선행 호출이 없음을 검증하는 테스트를 추가했습니다.

## 테스트
- `./scripts/start.sh --bootstrap-only`
- `make doctor`
- `./venv/bin/python -m unittest tests.test_setup_executor`
- `./venv/bin/python -m unittest discover -s tests -p 'test_*.py'`

## 주의사항
- 이번 수정은 ephemeral keychain 준비 단계의 선행 `security set-key-partition-list` 실패를 막는 목적입니다.
- 실제 signing identity import 이후 처리는 Fastlane `match` 흐름에 맡깁니다.